### PR TITLE
Improve i18n

### DIFF
--- a/.changeset/polite-fans-tap.md
+++ b/.changeset/polite-fans-tap.md
@@ -1,0 +1,6 @@
+---
+"@levino/shipyard-base": minor
+"@levino/shipyard-docs": minor
+---
+
+enable usage without i18n

--- a/package-lock.json
+++ b/package-lock.json
@@ -9936,7 +9936,7 @@
     },
     "packages/base": {
       "name": "@levino/shipyard-base",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "clsx": "^2.1.0",
         "ramda": "^0.29.1",
@@ -9959,10 +9959,10 @@
     },
     "packages/blog": {
       "name": "@levino/shipyard-blog",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "@levino/shipyard-base": "^0.2.0"
+        "@levino/shipyard-base": "^0.3.0"
       },
       "devDependencies": {
         "astro": "^5"
@@ -9973,10 +9973,10 @@
     },
     "packages/docs": {
       "name": "@levino/shipyard-docs",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
-        "@levino/shipyard-base": "^0.2.0",
+        "@levino/shipyard-base": "^0.3.0",
         "effect": "^3.12.5",
         "ramda": "^0.29.1"
       },

--- a/packages/base/astro/components/GlobalDesktopNavigation.astro
+++ b/packages/base/astro/components/GlobalDesktopNavigation.astro
@@ -1,5 +1,5 @@
 ---
-import type { Config } from "../../schemas/config";
+import type { Config } from "../../src/schemas/config";
 import { cn } from "../../src/tools/cn";
 
 type Props = Pick<Config, "brand" | "navigation"> & { showBrand: boolean };

--- a/packages/base/astro/layouts/Footer.astro
+++ b/packages/base/astro/layouts/Footer.astro
@@ -1,11 +1,15 @@
 ---
 import { Footer as FooterComponent } from "../components";
+import config from "virtual:shipyard/config";
 
-const locale = Astro.currentLocale;
+const locale = Astro.currentLocale || config.defaultLocale;
+
+const withLocale = (path: string) =>
+  locale === config.defaultLocale ? path : `/${locale}${path}`;
 ---
 
 <FooterComponent
-  links={[{ href: `/${locale}/imprint`, label: "Impressum" }]}
+  links={[{ href: withLocale("/imprint"), label: "Impressum" }]}
   copyright={{
     href: "https://github.com/levino",
     label: "Levin Keller",

--- a/packages/base/astro/layouts/Page.astro
+++ b/packages/base/astro/layouts/Page.astro
@@ -18,16 +18,16 @@ type Props = {
   sidebarNavigation?: NavigationTree;
 };
 
-const locale = Astro.currentLocale || "de";
+const currentLocale = Astro.currentLocale || config.defaultLocale;
 const currentPath = Astro.url.pathname;
 const props = Astro.props.frontmatter || Astro.props;
 
-const withLocale = (locale: string) => (path: string) => `/${locale}${path}`;
-const withCurrentLocale = withLocale(locale);
+const withLocale = (path: string) =>
+  currentLocale === config.defaultLocale ? path : `/${currentLocale}${path}`;
 const applyLocaleAndSetActive: (navigation: NavigationTree) => NavigationTree =
   mapObjIndexed((entry: NavigationEntry) => ({
     ...entry,
-    ...(entry.href ? { href: withCurrentLocale(entry.href) } : {}),
+    ...(entry.href ? { href: withLocale(entry.href) } : {}),
     active: entry.href === currentPath,
     ...(entry.subEntry
       ? { subEntry: applyLocaleAndSetActive(entry.subEntry) }
@@ -35,8 +35,7 @@ const applyLocaleAndSetActive: (navigation: NavigationTree) => NavigationTree =
   }));
 
 const navigation = applyLocaleAndSetActive(config.navigation);
-const title =         `${config.title} - ${props.title}`
-
+const title = `${config.title} - ${props.title}`;
 ---
 
 <html>
@@ -44,9 +43,7 @@ const title =         `${config.title} - ${props.title}`
     <meta charset="utf-8" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <title>
-      {
-        title
-      }
+      {title}
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={props.description} />

--- a/packages/docs/astro/DefaultLocaleDocsEntry.astro
+++ b/packages/docs/astro/DefaultLocaleDocsEntry.astro
@@ -1,0 +1,20 @@
+---
+import Layout from "./Layout.astro";
+import { getCollection, render } from "astro:content";
+
+export async function getStaticPaths() {
+  const docs = await getCollection("docs");
+
+  return docs.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+// 2. For your template, you can get the entry directly from the prop
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<Layout>
+  <Content />
+</Layout>

--- a/packages/docs/astro/DocsEntry.astro
+++ b/packages/docs/astro/DocsEntry.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "./Layout.astro";
 import { getCollection, render } from "astro:content";
-
+import config from "virtual:shipyard/config";
 export async function getStaticPaths() {
   const getParams = (slug: string) => {
     const [locale, ...rest] = slug.split("/");
@@ -12,10 +12,24 @@ export async function getStaticPaths() {
   };
   const docs = await getCollection("docs");
 
-  return docs.map((entry) => ({
-    params: getParams(entry.id),
-    props: { entry },
-  }));
+  return docs
+    .filter((entry) => {
+      const [, locale] = entry.id.split("/");
+      if (!locale) {
+        return true;
+      }
+      if (locale === config.defaultLocale) {
+        return false;
+      }
+      if (config.locales.includes(locale)) {
+        return true;
+      }
+      return false;
+    })
+    .map((entry) => ({
+      params: getParams(entry.id),
+      props: { entry },
+    }));
 }
 // 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;

--- a/packages/docs/astro/Layout.astro
+++ b/packages/docs/astro/Layout.astro
@@ -5,8 +5,13 @@ import { toSidebarEntries } from "../src/sidebarEntries";
 import { path } from "ramda";
 import type { NavigationTree } from "@levino/shipyard-base";
 import { Array, Option } from "effect";
+import config from "virtual:shipyard/config";
 
-const locale = Astro.currentLocale as string;
+const locale = (Astro.currentLocale as string) ?? config.defaultLocale;
+const getPath = (id: string) =>
+  locale === config.defaultLocale
+    ? `/docs/${id}`
+    : `/${locale}/docs/${id.slice(3)}`;
 const docs = await getCollection("docs")
   .then(
     Array.map(async (doc) => {
@@ -18,7 +23,7 @@ const docs = await getCollection("docs")
         },
       } = doc;
       return {
-        path: `/${locale}/docs/${id.slice(3)}`,
+        path: getPath(id),
         title:
           label ??
           title ??
@@ -35,9 +40,11 @@ const docs = await getCollection("docs")
   )
   .then(Promise.all.bind(Promise));
 
-const entries = path([locale, "subEntry", "docs", "subEntry"])(
-  toSidebarEntries(docs),
-) as NavigationTree;
+const entries = (
+  locale == config.defaultLocale
+    ? path(["docs", "subEntry"])
+    : path([locale, "subEntry", "docs", "subEntry"])
+)(toSidebarEntries(docs)) as NavigationTree;
 ---
 
 <BaseLayout sidebarNavigation={entries}>

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -19,6 +19,11 @@ export default (docsPaths: string[]): AstroIntegration => ({
     'astro:config:setup': ({ injectRoute }) => {
       docsPaths.forEach((path) => {
         injectRoute({
+          pattern: `/${path}/[...slug]`,
+          entrypoint:
+            `@levino/shipyard-docs/astro/DefaultLocaleDocsEntry.astro`,
+        })
+        injectRoute({
           pattern: `/[locale]/${path}/[...slug]`,
           entrypoint: `@levino/shipyard-docs/astro/DocsEntry.astro`,
         })


### PR DESCRIPTION
I am trying to migrate rössing.de to use shipyard. However the content there is not translated but German only. So I need to improve the i18n functionality in order to support single language pages.