### PR TITLE
Add script injection capability to Shipyard

### DIFF
--- a/.changeset/add-script-injection.md
+++ b/.changeset/add-script-injection.md
@@ -1,0 +1,5 @@
+---
+"@levino/shipyard-base": patch
+---
+
+Add script injection capability to allow adding script tags to the HTML head. Supports both string URLs and object configurations with attributes like async, defer, and type. See #40.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowed-tools Bash(npx:*)
+          claude_args: --allowed-tools Bash(npx @biomejs/biome:*)
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+          claude_args: --allowed-tools npx
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -66,4 +66,4 @@ call_lefthook()
   fi
 }
 
-call_lefthook run "pre-commit" "$@"
+call_lefthook run "prepare-commit-msg" "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,23 @@ Documentation features:
 
 6. **Git Hooks**: Husky is configured to run `biome check --write` on pre-commit to automatically fix linting/formatting issues.
 
+## Essential Claude Workflow
+
+### Before Making Commits
+**CRITICAL**: Always run the following command before committing changes:
+
+```bash
+npx biome check --fix
+```
+
+This ensures:
+- Code is properly formatted according to project standards
+- Linting issues are automatically resolved
+- Import statements are organized
+- Consistent code style across the codebase
+
+If biome makes any changes, make sure to stage and include them in your commit.
+
 ## Working with Components
 
 - Astro components are in `packages/*/astro/` directories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ npm run test:e2e
 npm run test:e2e:ui
 
 # Check and fix linting/formatting issues
-npx biome check --fix
+npx biome check --write
 
 # Check linting/formatting without fixing
 npx biome check
@@ -132,7 +132,7 @@ Documentation features:
 **CRITICAL**: Always run the following command before committing changes:
 
 ```bash
-npx biome check --fix
+npx biome check --write
 ```
 
 This ensures:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,23 +126,6 @@ Documentation features:
 
 6. **Git Hooks**: Husky is configured to run `biome check --write` on pre-commit to automatically fix linting/formatting issues.
 
-## Essential Claude Workflow
-
-### Before Making Commits
-**CRITICAL**: Always run the following command before committing changes:
-
-```bash
-npx biome check --write
-```
-
-This ensures:
-- Code is properly formatted according to project standards
-- Linting issues are automatically resolved
-- Import statements are organized
-- Consistent code style across the codebase
-
-If biome makes any changes, make sure to stage and include them in your commit.
-
 ## Working with Components
 
 - Astro components are in `packages/*/astro/` directories

--- a/apps/demo/astro.config.mjs
+++ b/apps/demo/astro.config.mjs
@@ -43,6 +43,18 @@ export default defineConfig({
       title: 'Metro Gardens',
       tagline: 'Growing community, one plant at a time.',
       brand: 'Metro Gardens',
+      scripts: [
+        'https://example.com/simple-script.js',
+        {
+          src: 'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+          async: true,
+        },
+        {
+          src: 'https://example.com/deferred-script.js',
+          defer: true,
+          type: 'module',
+        },
+      ],
     }),
     shipyardDocs(['docs']),
     shipyardBlog(['blog']),

--- a/apps/demo/astro.config.mjs
+++ b/apps/demo/astro.config.mjs
@@ -44,13 +44,13 @@ export default defineConfig({
       tagline: 'Growing community, one plant at a time.',
       brand: 'Metro Gardens',
       scripts: [
-        'https://example.com/simple-script.js',
+        'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
         {
-          src: 'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
+          src: 'https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js',
           async: true,
         },
         {
-          src: 'https://example.com/deferred-script.js',
+          src: 'https://cdn.skypack.dev/lodash-es',
           defer: true,
           type: 'module',
         },

--- a/apps/demo/tests/e2e/scripts.spec.ts
+++ b/apps/demo/tests/e2e/scripts.spec.ts
@@ -8,21 +8,21 @@ test.describe('Script Injection Tests', () => {
     const scripts = await page.locator('head script').all()
     expect(scripts).toHaveLength(3)
 
-    // Test simple string script
-    const simpleScript = page.locator('head script[src="https://example.com/simple-script.js"]')
+    // Test simple string script (jQuery)
+    const simpleScript = page.locator('head script[src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"]')
     await expect(simpleScript).toBeAttached()
     
     // Verify it doesn't have async or defer attributes
     expect(await simpleScript.getAttribute('async')).toBeNull()
     expect(await simpleScript.getAttribute('defer')).toBeNull()
 
-    // Test script with async attribute
-    const asyncScript = page.locator('head script[src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"]')
+    // Test script with async attribute (PocketBase)
+    const asyncScript = page.locator('head script[src="https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js"]')
     await expect(asyncScript).toBeAttached()
     expect(await asyncScript.getAttribute('async')).toBe('')
 
-    // Test script with defer and type attributes
-    const deferredScript = page.locator('head script[src="https://example.com/deferred-script.js"]')
+    // Test script with defer and type attributes (Lodash ES)
+    const deferredScript = page.locator('head script[src="https://cdn.skypack.dev/lodash-es"]')
     await expect(deferredScript).toBeAttached()
     expect(await deferredScript.getAttribute('defer')).toBe('')
     expect(await deferredScript.getAttribute('type')).toBe('module')
@@ -48,20 +48,20 @@ test.describe('Script Injection Tests', () => {
   test('script attributes are correctly applied', async ({ page }) => {
     await page.goto('/en')
     
-    // Verify the clipboard.js script has the correct attributes
-    const clipboardScript = page.locator('head script[src*="clipboard.js"]')
-    await expect(clipboardScript).toBeAttached()
+    // Verify the PocketBase script has the correct attributes
+    const pocketbaseScript = page.locator('head script[src*="pocketbase"]')
+    await expect(pocketbaseScript).toBeAttached()
     
     // Check for async attribute
-    const isAsync = await clipboardScript.evaluate(script => script.hasAttribute('async'))
+    const isAsync = await pocketbaseScript.evaluate(script => script.hasAttribute('async'))
     expect(isAsync).toBe(true)
     
     // Check that defer is not set (should be null/false)
-    const hasDefer = await clipboardScript.evaluate(script => script.hasAttribute('defer'))
+    const hasDefer = await pocketbaseScript.evaluate(script => script.hasAttribute('defer'))
     expect(hasDefer).toBe(false)
     
-    // Verify the deferred script has correct attributes
-    const deferredScript = page.locator('head script[src*="deferred-script.js"]')
+    // Verify the Lodash ES script has correct attributes
+    const deferredScript = page.locator('head script[src*="lodash-es"]')
     await expect(deferredScript).toBeAttached()
     
     const isDefer = await deferredScript.evaluate(script => script.hasAttribute('defer'))
@@ -82,8 +82,8 @@ test.describe('Script Injection Tests', () => {
     )
     
     // Verify scripts appear in the same order as configured
-    expect(srcs[0]).toBe('https://example.com/simple-script.js')
-    expect(srcs[1]).toBe('https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js')
-    expect(srcs[2]).toBe('https://example.com/deferred-script.js')
+    expect(srcs[0]).toBe('https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js')
+    expect(srcs[1]).toBe('https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js')
+    expect(srcs[2]).toBe('https://cdn.skypack.dev/lodash-es')
   })
 })

--- a/apps/demo/tests/e2e/scripts.spec.ts
+++ b/apps/demo/tests/e2e/scripts.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Script Injection Tests', () => {
+  test('scripts are injected into HTML head', async ({ page }) => {
+    await page.goto('/en')
+
+    // Check that all three configured scripts are present in the head
+    const scripts = await page.locator('head script').all()
+    expect(scripts).toHaveLength(3)
+
+    // Test simple string script
+    const simpleScript = page.locator('head script[src="https://example.com/simple-script.js"]')
+    await expect(simpleScript).toBeAttached()
+    
+    // Verify it doesn't have async or defer attributes
+    expect(await simpleScript.getAttribute('async')).toBeNull()
+    expect(await simpleScript.getAttribute('defer')).toBeNull()
+
+    // Test script with async attribute
+    const asyncScript = page.locator('head script[src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"]')
+    await expect(asyncScript).toBeAttached()
+    expect(await asyncScript.getAttribute('async')).toBe('')
+
+    // Test script with defer and type attributes
+    const deferredScript = page.locator('head script[src="https://example.com/deferred-script.js"]')
+    await expect(deferredScript).toBeAttached()
+    expect(await deferredScript.getAttribute('defer')).toBe('')
+    expect(await deferredScript.getAttribute('type')).toBe('module')
+  })
+
+  test('scripts are present on different pages', async ({ page }) => {
+    // Test about page
+    await page.goto('/en/about')
+    const aboutScripts = await page.locator('head script').all()
+    expect(aboutScripts).toHaveLength(3)
+
+    // Test blog page  
+    await page.goto('/en/blog')
+    const blogScripts = await page.locator('head script').all()
+    expect(blogScripts).toHaveLength(3)
+
+    // Test docs page
+    await page.goto('/en/docs')
+    const docsScripts = await page.locator('head script').all()
+    expect(docsScripts).toHaveLength(3)
+  })
+
+  test('script attributes are correctly applied', async ({ page }) => {
+    await page.goto('/en')
+    
+    // Verify the clipboard.js script has the correct attributes
+    const clipboardScript = page.locator('head script[src*="clipboard.js"]')
+    await expect(clipboardScript).toBeAttached()
+    
+    // Check for async attribute
+    const isAsync = await clipboardScript.evaluate(script => script.hasAttribute('async'))
+    expect(isAsync).toBe(true)
+    
+    // Check that defer is not set (should be null/false)
+    const hasDefer = await clipboardScript.evaluate(script => script.hasAttribute('defer'))
+    expect(hasDefer).toBe(false)
+    
+    // Verify the deferred script has correct attributes
+    const deferredScript = page.locator('head script[src*="deferred-script.js"]')
+    await expect(deferredScript).toBeAttached()
+    
+    const isDefer = await deferredScript.evaluate(script => script.hasAttribute('defer'))
+    expect(isDefer).toBe(true)
+    
+    const scriptType = await deferredScript.getAttribute('type')
+    expect(scriptType).toBe('module')
+  })
+
+  test('scripts are in correct order', async ({ page }) => {
+    await page.goto('/en')
+    
+    const allScripts = await page.locator('head script').all()
+    
+    // Get src attributes in order
+    const srcs = await Promise.all(
+      allScripts.map(script => script.getAttribute('src'))
+    )
+    
+    // Verify scripts appear in the same order as configured
+    expect(srcs[0]).toBe('https://example.com/simple-script.js')
+    expect(srcs[1]).toBe('https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js')
+    expect(srcs[2]).toBe('https://example.com/deferred-script.js')
+  })
+})

--- a/apps/demo/tests/e2e/scripts.spec.ts
+++ b/apps/demo/tests/e2e/scripts.spec.ts
@@ -9,7 +9,9 @@ test.describe('Script Injection Tests', () => {
     expect(scripts).toHaveLength(3)
 
     // Test simple string script (jQuery)
-    const simpleScript = page.locator('head script[src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"]')
+    const simpleScript = page.locator(
+      'head script[src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"]',
+    )
     await expect(simpleScript).toBeAttached()
     
     // Verify it doesn't have async or defer attributes

--- a/apps/demo/tests/e2e/scripts.spec.ts
+++ b/apps/demo/tests/e2e/scripts.spec.ts
@@ -13,7 +13,6 @@ test.describe('Script Injection Tests', () => {
       'head script[src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"]',
     )
     await expect(simpleScript).toBeAttached()
-    
     // Verify it doesn't have async or defer attributes
     expect(await simpleScript.getAttribute('async')).toBeNull()
     expect(await simpleScript.getAttribute('defer')).toBeNull()

--- a/apps/demo/tests/e2e/scripts.spec.ts
+++ b/apps/demo/tests/e2e/scripts.spec.ts
@@ -18,12 +18,16 @@ test.describe('Script Injection Tests', () => {
     expect(await simpleScript.getAttribute('defer')).toBeNull()
 
     // Test script with async attribute (PocketBase)
-    const asyncScript = page.locator('head script[src="https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js"]')
+    const asyncScript = page.locator(
+      'head script[src="https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js"]',
+    )
     await expect(asyncScript).toBeAttached()
     expect(await asyncScript.getAttribute('async')).toBe('')
 
     // Test script with defer and type attributes (Lodash ES)
-    const deferredScript = page.locator('head script[src="https://cdn.skypack.dev/lodash-es"]')
+    const deferredScript = page.locator(
+      'head script[src="https://cdn.skypack.dev/lodash-es"]',
+    )
     await expect(deferredScript).toBeAttached()
     expect(await deferredScript.getAttribute('defer')).toBe('')
     expect(await deferredScript.getAttribute('type')).toBe('module')
@@ -35,7 +39,7 @@ test.describe('Script Injection Tests', () => {
     const aboutScripts = await page.locator('head script').all()
     expect(aboutScripts).toHaveLength(3)
 
-    // Test blog page  
+    // Test blog page
     await page.goto('/en/blog')
     const blogScripts = await page.locator('head script').all()
     expect(blogScripts).toHaveLength(3)
@@ -48,43 +52,53 @@ test.describe('Script Injection Tests', () => {
 
   test('script attributes are correctly applied', async ({ page }) => {
     await page.goto('/en')
-    
+
     // Verify the PocketBase script has the correct attributes
     const pocketbaseScript = page.locator('head script[src*="pocketbase"]')
     await expect(pocketbaseScript).toBeAttached()
-    
+
     // Check for async attribute
-    const isAsync = await pocketbaseScript.evaluate(script => script.hasAttribute('async'))
+    const isAsync = await pocketbaseScript.evaluate((script) =>
+      script.hasAttribute('async'),
+    )
     expect(isAsync).toBe(true)
-    
+
     // Check that defer is not set (should be null/false)
-    const hasDefer = await pocketbaseScript.evaluate(script => script.hasAttribute('defer'))
+    const hasDefer = await pocketbaseScript.evaluate((script) =>
+      script.hasAttribute('defer'),
+    )
     expect(hasDefer).toBe(false)
-    
+
     // Verify the Lodash ES script has correct attributes
     const deferredScript = page.locator('head script[src*="lodash-es"]')
     await expect(deferredScript).toBeAttached()
-    
-    const isDefer = await deferredScript.evaluate(script => script.hasAttribute('defer'))
+
+    const isDefer = await deferredScript.evaluate((script) =>
+      script.hasAttribute('defer'),
+    )
     expect(isDefer).toBe(true)
-    
+
     const scriptType = await deferredScript.getAttribute('type')
     expect(scriptType).toBe('module')
   })
 
   test('scripts are in correct order', async ({ page }) => {
     await page.goto('/en')
-    
+
     const allScripts = await page.locator('head script').all()
-    
+
     // Get src attributes in order
     const srcs = await Promise.all(
-      allScripts.map(script => script.getAttribute('src'))
+      allScripts.map((script) => script.getAttribute('src')),
     )
-    
+
     // Verify scripts appear in the same order as configured
-    expect(srcs[0]).toBe('https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js')
-    expect(srcs[1]).toBe('https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js')
+    expect(srcs[0]).toBe(
+      'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
+    )
+    expect(srcs[1]).toBe(
+      'https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js',
+    )
     expect(srcs[2]).toBe('https://cdn.skypack.dev/lodash-es')
   })
 })

--- a/apps/docs/docs/en/feature.md
+++ b/apps/docs/docs/en/feature.md
@@ -109,3 +109,171 @@ tailwind({
 ```
 
 This prevents conflicts with Shipyard's built-in styles.
+
+## Script Injection
+
+Shipyard allows you to inject external scripts into your site's HTML head, similar to Docusaurus. This is useful for adding analytics, chat widgets, CDN libraries, or any third-party scripts.
+
+### Basic Usage
+
+Scripts are configured in your `shipyard()` configuration using the `scripts` array:
+
+```javascript
+shipyard({
+  // ... other configuration
+  scripts: [
+    // Simple string format
+    'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
+    
+    // Object format with attributes
+    {
+      src: 'https://cdn.jsdelivr.net/npm/pocketbase@0.21.5/dist/pocketbase.umd.js',
+      async: true,
+    },
+  ],
+})
+```
+
+### Configuration Formats
+
+#### String Format
+
+For simple script injection without special attributes:
+
+```javascript
+scripts: [
+  'https://example.com/script.js',
+  'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js',
+]
+```
+
+#### Object Format
+
+For scripts that need special attributes or loading behavior:
+
+```javascript
+scripts: [
+  {
+    src: 'https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID',
+    async: true,
+  },
+  {
+    src: 'https://cdn.skypack.dev/lodash-es',
+    defer: true,
+    type: 'module',
+  },
+  {
+    src: 'https://cdn.example.com/secure-script.js',
+    integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC',
+    crossorigin: 'anonymous',
+  },
+]
+```
+
+### Supported Attributes
+
+All standard HTML script attributes are supported:
+
+- **`src`** (required): The URL of the script
+- **`async`**: Load script asynchronously without blocking HTML parsing
+- **`defer`**: Load script after HTML parsing is complete
+- **`type`**: Script MIME type (e.g., `'module'`, `'text/javascript'`)
+- **`crossorigin`**: CORS setting (`'anonymous'`, `'use-credentials'`)
+- **`integrity`**: Subresource Integrity hash for security
+- **`referrerpolicy`**: Referrer policy for the request
+
+You can also use any other valid HTML attributes:
+
+```javascript
+{
+  src: 'https://example.com/script.js',
+  'data-domain': 'yourdomain.com',
+  'data-api': '/api/event',
+}
+```
+
+### Loading Strategies
+
+#### Async Loading
+Best for scripts that don't depend on DOM content and can run independently:
+
+```javascript
+{
+  src: 'https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID',
+  async: true,
+}
+```
+
+#### Deferred Loading
+Best for scripts that need the DOM to be fully parsed:
+
+```javascript
+{
+  src: 'https://example.com/dom-dependent-script.js',
+  defer: true,
+}
+```
+
+#### ES Modules
+For modern JavaScript modules:
+
+```javascript
+{
+  src: 'https://cdn.skypack.dev/lodash-es',
+  type: 'module',
+  defer: true,
+}
+```
+
+### Common Use Cases
+
+#### Analytics
+```javascript
+scripts: [
+  {
+    src: 'https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID',
+    async: true,
+  },
+]
+```
+
+#### CDN Libraries
+```javascript
+scripts: [
+  'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
+  'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js',
+]
+```
+
+#### Chat Widgets
+```javascript
+scripts: [
+  {
+    src: 'https://widget.intercom.io/widget/your-app-id',
+    async: true,
+  },
+]
+```
+
+### Important Notes
+
+- **Global injection**: Scripts are injected into every page of your site
+- **Load order**: Scripts are loaded in the order they appear in the configuration
+- **Performance**: Use `async` or `defer` attributes to avoid blocking page rendering
+- **Security**: Consider using `integrity` attributes for third-party CDN scripts
+- **Server-side rendering**: Scripts are injected during build time, not at runtime
+
+### Security Considerations
+
+When adding external scripts:
+
+1. **Use trusted sources**: Only include scripts from reputable CDNs and services
+2. **Subresource Integrity**: Use `integrity` hashes when possible:
+   ```javascript
+   {
+     src: 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js',
+     integrity: 'sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=',
+     crossorigin: 'anonymous',
+   }
+   ```
+3. **Content Security Policy**: Configure CSP headers if using strict security policies

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  commands:
+    check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      stage_fixed: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.2",
-        "husky": "^8.0.3",
+        "lefthook": "^1.12.3",
         "lint-staged": "^15.2.0",
         "turbo": "^2.3.3",
         "typescript": "^5.3.3"
@@ -4911,22 +4911,6 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5197,6 +5181,169 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.3.tgz",
+      "integrity": "sha512-huMg+mGp6wHPjkaLdchuOvxVRMzvz6OVdhivatiH2Qn47O5Zm46jwzbVPYIanX6N/8ZTjGLBxv8tZ0KYmKt/Jg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.12.3",
+        "lefthook-darwin-x64": "1.12.3",
+        "lefthook-freebsd-arm64": "1.12.3",
+        "lefthook-freebsd-x64": "1.12.3",
+        "lefthook-linux-arm64": "1.12.3",
+        "lefthook-linux-x64": "1.12.3",
+        "lefthook-openbsd-arm64": "1.12.3",
+        "lefthook-openbsd-x64": "1.12.3",
+        "lefthook-windows-arm64": "1.12.3",
+        "lefthook-windows-x64": "1.12.3"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.3.tgz",
+      "integrity": "sha512-j1lwaosWRy3vhz8oQgCS1M6EUFN95aIYeNuqkczsBoAA6BDNAmVP1ctYEIYUK4bYaIgENbqbA9prYMAhyzh6Og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.3.tgz",
+      "integrity": "sha512-x6aWFfLQX4m5zQ4X9zh5+hHOE5XTvNjz2zB9DI+xbIBLs2RRg0xJNT3OfgSrBU1QtEBneJ5dRQP5nl47td9GDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-41OmulLqVZ0EOHmmHouJrpL59SwDD7FLoso4RsQVIBPaf8fHacdLo07Ye28VWQ5XolZQvnWcr1YXKo4JhqQMyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.3.tgz",
+      "integrity": "sha512-741/JRCJIS++hgYEH2uefN4FsH872V7gy2zDhcfQofiZnWP7+qhl4Wmwi8IpjIu4X7hLOC4cT18LOVU5L8KV9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.3.tgz",
+      "integrity": "sha512-BXIy1aDFZmFgmebJliNrEqZfX1lSOD4b/USvANv1UirFrNgTq5SRssd1CKfflT2PwKX6LsJTD4WabLLWZOxp9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.3.tgz",
+      "integrity": "sha512-FRdwdj5jsQAP2eVrtkVUqMqYNCbQ2Ix84izy29/BvLlu/hVypAGbDfUkgFnsmAd6ZsCBeYCEtPuqyg3E3SO0Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-tch5wXY4GOjKAYohH7OFoxNdVHuUSYt2Pulo2VTkMYEG8IrvJnRO5MkvgHtKDHzU5mfABQYv5+ccJykDx5hQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.3.tgz",
+      "integrity": "sha512-IHbHg/rUFXrAN7LnjcQEtutCHBaD49CZge96Hpk0GZ2eEG5GTCNRnUyEf+Kf3+RTqHFgwtADdpeDa/ZaGZTM4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.3.tgz",
+      "integrity": "sha512-wghcE5TSpb+mbtemUV6uAo9hEK09kxRzhf2nPdeDX+fw42cL2TGZsbaCnDyzaY144C+L2/wEWrLIHJMnZYkuqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.3.tgz",
+      "integrity": "sha512-7Co/L8e2x2hGC1L33jDJ4ZlTkO3PJm25GOGpLfN1kqwhGB/uzMLeTI/PBczjlIN8isUv26ouNd9rVR7Bibrwyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,17 @@
 {
   "scripts": {
-    "prepare": "husky install || true",
     "test:e2e": "cd apps/demo && npm run test:e2e",
     "test:e2e:ui": "cd apps/demo && npm run test:e2e:ui",
     "test:e2e:single-locale": "cd apps/single-locale-demo && npm run test:e2e",
     "test:e2e:single-locale:ui": "cd apps/single-locale-demo && npm run test:e2e:ui"
   },
-  "prepare": "husky",
   "keywords": [],
   "author": "",
   "private": true,
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
-    "husky": "^8.0.3",
+    "lefthook": "^1.12.3",
     "lint-staged": "^15.2.0",
     "turbo": "^2.3.3",
     "typescript": "^5.3.3"

--- a/packages/base/astro/layouts/Page.astro
+++ b/packages/base/astro/layouts/Page.astro
@@ -3,7 +3,7 @@ import Footer from './Footer.astro'
 import '../../src/globals.css'
 import config from 'virtual:shipyard/config'
 import { mapObjIndexed } from 'ramda'
-import type { NavigationEntry, NavigationTree } from '../../src/schemas/config'
+import type { NavigationEntry, NavigationTree, Script } from '../../src/schemas/config'
 import { getTitle } from '../../src/tools/title'
 import { GlobalDesktopNavigation, SidebarNavigation } from '../components'
 
@@ -35,6 +35,14 @@ const applyLocaleAndSetActive: (navigation: NavigationTree) => NavigationTree =
 
 const navigation = applyLocaleAndSetActive(config.navigation)
 const title = getTitle(config.title, props.title)
+
+// Helper function to render script attributes
+const renderScriptAttributes = (script: Script) => {
+  if (typeof script === 'string') {
+    return { src: script }
+  }
+  return script
+}
 ---
 
 <html>
@@ -48,6 +56,11 @@ const title = getTitle(config.title, props.title)
     <meta name="description" content={props.description} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={props.description} />
+    
+    {config.scripts?.map((script) => {
+      const attrs = renderScriptAttributes(script)
+      return <script {...attrs}></script>
+    })}
   </head>
   <body>
     <div class="drawer lg:drawer-open">

--- a/packages/base/astro/layouts/Page.astro
+++ b/packages/base/astro/layouts/Page.astro
@@ -3,7 +3,11 @@ import Footer from './Footer.astro'
 import '../../src/globals.css'
 import config from 'virtual:shipyard/config'
 import { mapObjIndexed } from 'ramda'
-import type { NavigationEntry, NavigationTree, Script } from '../../src/schemas/config'
+import type {
+  NavigationEntry,
+  NavigationTree,
+  Script,
+} from '../../src/schemas/config'
 import { getTitle } from '../../src/tools/title'
 import { GlobalDesktopNavigation, SidebarNavigation } from '../components'
 

--- a/packages/base/astro/layouts/Page.astro
+++ b/packages/base/astro/layouts/Page.astro
@@ -59,7 +59,7 @@ const renderScriptAttributes = (script: Script) => {
     
     {config.scripts?.map((script) => {
       const attrs = renderScriptAttributes(script)
-      return <script {...attrs}></script>
+      return <script is:inline {...attrs}></script>
     })}
   </head>
   <body>

--- a/packages/base/src/schemas/config.ts
+++ b/packages/base/src/schemas/config.ts
@@ -9,11 +9,25 @@ export interface NavigationEntry {
 
 export type NavigationTree = Record<string, NavigationEntry>
 
+export interface ScriptConfig {
+  src: string
+  async?: boolean
+  defer?: boolean
+  type?: string
+  crossorigin?: string
+  integrity?: string
+  referrerpolicy?: string
+  [key: string]: string | boolean | undefined
+}
+
+export type Script = string | ScriptConfig
+
 export interface Config {
   brand: string
   navigation: NavigationTree
   title: string
   tagline: string
+  scripts?: Script[]
 }
 
 export interface FinalConfig extends Config {


### PR DESCRIPTION
Add script injection capability to Shipyard, similar to Docusaurus functionality.

- Add `scripts` configuration option to Config interface
- Support both string URLs and object configurations with attributes
- Modify Page layout to render script tags in HTML head
- Add comprehensive E2E tests for script functionality
- Add changeset for patch version

Fixes #40

Generated with [Claude Code](https://claude.ai/code)