### PR TITLE
Fix Gemini mentions not triggering workflows

### DIFF
--- a/.github/GEMINI_SETUP.md
+++ b/.github/GEMINI_SETUP.md
@@ -2,6 +2,8 @@
 
 This guide explains how to configure the Gemini CLI integration for your GitHub repository.
 
+> **Official Documentation**: https://github.com/google-github-actions/run-gemini-cli
+
 ## Overview
 
 The Gemini CLI integration provides three main capabilities:
@@ -9,52 +11,55 @@ The Gemini CLI integration provides three main capabilities:
 2. **Issue Triage** (`@gemini-cli /triage`) - Automatic issue labeling
 3. **General Assistant** (`@gemini-cli`) - Implementation assistance (requires approval)
 
-## Required GitHub Secrets
+**Important**: The workflows are based on [official Google examples](https://github.com/google-github-actions/run-gemini-cli/tree/main/examples/workflows).
 
-Configure these secrets in your repository settings (Settings → Secrets and variables → Actions):
+## GitHub Configuration
 
-### Essential Secrets
+### Required Secrets
 
-1. **`GEMINI_API_KEY`** or **`GOOGLE_API_KEY`** (at least one required)
-   - Get your API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
-   - Or use Google Cloud's Vertex AI (see GCP setup below)
+Configure in: **Settings → Secrets and variables → Actions → Secrets**
 
-2. **`APP_PRIVATE_KEY`** (recommended but optional)
-   - Private key for a GitHub App with permissions:
-     - Contents: Read
-     - Issues: Write
-     - Pull Requests: Write
-   - Allows Gemini to post comments as the app instead of using the default GITHUB_TOKEN
+1. **`GEMINI_API_KEY`** (REQUIRED)
+   - Get from [Google AI Studio](https://aistudio.google.com/app/apikey)
+   - Free tier available for testing
+   - Alternative: Use `GOOGLE_API_KEY` for Vertex AI mode
 
-## Required GitHub Variables
-
-Configure these variables in your repository settings (Settings → Secrets and variables → Actions → Variables):
-
-### Essential Variables
-
-1. **`GEMINI_MODEL`** (required)
-   - Example: `"gemini-2.0-flash-exp"` or `"gemini-1.5-pro"`
-   - See [available models](https://ai.google.dev/models)
-
-2. **`GEMINI_CLI_VERSION`** (required)
-   - Example: `"0.16.0"`
-   - Check [latest version](https://www.npmjs.com/package/@google/gemini-cli)
+2. **`APP_PRIVATE_KEY`** (Optional but recommended)
+   - Private key for a GitHub App
+   - Allows Gemini to post as an app bot instead of using GITHUB_TOKEN
+   - Required permissions: Contents (read), Issues (write), PRs (write)
+   - [How to create a GitHub App](https://docs.github.com/en/apps/creating-github-apps)
 
 ### Optional Variables
 
+Configure in: **Settings → Secrets and variables → Actions → Variables**
+
+**Note**: These are OPTIONAL. The action has sensible defaults.
+
+1. **`GEMINI_MODEL`** (optional, has defaults)
+   - Example: `gemini-2.0-flash-exp` or `gemini-1.5-pro`
+   - Default: Uses the action's default model
+   - [Available models](https://ai.google.dev/models)
+
+2. **`GEMINI_CLI_VERSION`** (optional)
+   - Example: `0.16.0`
+   - Default: `latest`
+   - [Latest versions](https://www.npmjs.com/package/@google/gemini-cli)
+
 3. **`APP_ID`** (optional, required if using `APP_PRIVATE_KEY`)
    - Your GitHub App ID
+   - Found in GitHub App settings
 
 4. **`DEBUG`** or **`ACTIONS_STEP_DEBUG`** (optional)
    - Set to `true` to enable debug logging
    - Default: `false`
 
-### GCP/Vertex AI Variables (optional)
+### Advanced: GCP/Vertex AI Variables (optional)
 
-If using Google Cloud's Vertex AI instead of the direct API:
+If using Google Cloud's Vertex AI instead of the direct Gemini API:
 
 5. **`GOOGLE_GENAI_USE_VERTEXAI`** - Set to `true`
-6. **`GOOGLE_CLOUD_LOCATION`** - GCP region (e.g., `"us-central1"`)
+6. **`GOOGLE_CLOUD_LOCATION`** - GCP region (e.g., `us-central1`)
 7. **`GOOGLE_CLOUD_PROJECT`** - Your GCP project ID
 8. **`SERVICE_ACCOUNT_EMAIL`** - Service account email
 9. **`GCP_WIF_PROVIDER`** - Workload Identity Federation provider
@@ -62,14 +67,16 @@ If using Google Cloud's Vertex AI instead of the direct API:
 
 ## Quick Setup (Minimal Configuration)
 
-For a basic setup, you only need:
+**Minimum required for basic setup:**
 
-1. **Secrets:**
-   - `GEMINI_API_KEY` (from Google AI Studio)
+1. **ONE Secret (required):**
+   - `GEMINI_API_KEY` - Get from [Google AI Studio](https://aistudio.google.com/app/apikey)
 
-2. **Variables:**
-   - `GEMINI_MODEL`: `gemini-2.0-flash-exp`
-   - `GEMINI_CLI_VERSION`: `0.16.0`
+2. **Variables (optional, recommended):**
+   - All variables are optional and have defaults
+   - Optionally set `GEMINI_MODEL` if you want a specific model
+
+**That's it!** The action will use sensible defaults for everything else.
 
 ## How to Use
 
@@ -105,17 +112,22 @@ Check:
 
 ### "Gemini acknowledged but never reported back"
 
-Check:
-1. Required secrets are configured (especially `GEMINI_API_KEY`)
-2. Required variables are configured (`GEMINI_MODEL`, `GEMINI_CLI_VERSION`)
-3. Your API key is valid and has quota remaining
-4. Check the [Actions tab](../../actions) for workflow logs
+**Now with improved error reporting!** Gemini will post the actual error message to your issue/PR when it fails.
+
+If you don't see an error comment:
+1. Check the [Actions tab](../../actions) for workflow logs
+2. Verify `GEMINI_API_KEY` is configured
+3. Ensure your API key is valid and has quota
+4. Check if the workflow timed out
 
 ### "Workflow failed with authentication error"
 
-This means:
-- `GEMINI_API_KEY` or `GOOGLE_API_KEY` is missing or invalid
-- If using Vertex AI, check your GCP credentials
+Look for the error comment on your issue/PR - it will contain the actual error from Gemini.
+
+Common causes:
+- `GEMINI_API_KEY` is missing, invalid, or revoked
+- API quota exceeded (check Google AI Studio)
+- If using Vertex AI, GCP credentials are incorrect
 
 ### "Workflow timed out"
 
@@ -138,15 +150,26 @@ If consistently timing out, check:
 
 ## Additional Resources
 
-- [Gemini CLI Documentation](https://github.com/google-github-actions/run-gemini-cli)
-- [Google AI Studio](https://aistudio.google.com/)
-- [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-- [Creating a GitHub App](https://docs.github.com/en/apps/creating-github-apps)
+### Official Documentation
+- **Main Repo**: https://github.com/google-github-actions/run-gemini-cli
+- **Example Workflows**: https://github.com/google-github-actions/run-gemini-cli/tree/main/examples/workflows
+- **Configuration Guide**: https://github.com/google-github-actions/run-gemini-cli/blob/main/examples/workflows/CONFIGURATION.md
+- **Gemini CLI Docs**: https://github.com/google-gemini/gemini-cli
+
+### Google Services
+- **Google AI Studio** (get API key): https://aistudio.google.com/app/apikey
+- **Available Models**: https://ai.google.dev/models
+- **Gemini CLI NPM**: https://www.npmjs.com/package/@google/gemini-cli
+
+### GitHub Docs
+- **GitHub Actions Secrets**: https://docs.github.com/en/actions/security-guides/encrypted-secrets
+- **Creating a GitHub App**: https://docs.github.com/en/apps/creating-github-apps
 
 ## Support
 
 If you encounter issues:
-1. Check the [workflow logs](../../actions) for detailed error messages
-2. Verify all required secrets and variables are configured
-3. Test your API key independently
-4. Check Google AI Studio for quota limits
+1. **Check error comments** - Gemini now posts actual errors to issues/PRs
+2. **Review [workflow logs](../../actions)** for detailed error messages
+3. Verify your `GEMINI_API_KEY` is configured and valid
+4. Check Google AI Studio for quota limits or API key status
+5. See official [troubleshooting](https://github.com/google-github-actions/run-gemini-cli#troubleshooting)

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -254,26 +254,39 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
-          MESSAGE: |-
-            🤖 I encountered an error while processing your request.
-
-            **Possible causes:**
-            - Missing or invalid API credentials (GEMINI_API_KEY or GOOGLE_API_KEY)
-            - Missing required configuration variables (GEMINI_MODEL, GEMINI_CLI_VERSION)
-            - Network or API connectivity issues
-            - The request exceeded the timeout limit
-
-            Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
-
-            **Required GitHub Secrets:**
-            - `GEMINI_API_KEY` or `GOOGLE_API_KEY` (at least one)
-            - `APP_PRIVATE_KEY` (if using GitHub App)
-
-            **Required GitHub Variables:**
-            - `GEMINI_MODEL` (e.g., "gemini-2.0-flash-exp")
-            - `GEMINI_CLI_VERSION` (e.g., "0.16.0")
+          ERROR_OUTPUT: '${{ steps.run_gemini.outputs.error }}'
+          SUMMARY_OUTPUT: '${{ steps.run_gemini.outputs.summary }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-
+          # Build error message
+          MESSAGE="🤖 I encountered an error while processing your request.
+
+          "
+
+          # Add actual error if available
+          if [[ -n "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Error:**
+          \`\`\`
+          ${ERROR_OUTPUT}
+          \`\`\`
+
+          "
+          fi
+
+          # Add summary if available and different from error
+          if [[ -n "${SUMMARY_OUTPUT}" && "${SUMMARY_OUTPUT}" != "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Summary:**
+          ${SUMMARY_OUTPUT}
+
+          "
+          fi
+
+          MESSAGE+="Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+
+          **Configuration:**
+          - [Gemini CLI Setup Guide](.github/GEMINI_SETUP.md)
+          - [Official Documentation](https://github.com/google-github-actions/run-gemini-cli)"
+
           gh issue comment "${ISSUE_NUMBER}" \
             --body "${MESSAGE}" \
             --repo "${REPOSITORY}"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -280,18 +280,39 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'
-          MESSAGE: |-
-            🤖 I encountered an error while reviewing this pull request.
-
-            **Possible causes:**
-            - Missing or invalid API credentials (GEMINI_API_KEY or GOOGLE_API_KEY)
-            - Missing required configuration variables (GEMINI_MODEL, GEMINI_CLI_VERSION)
-            - Network or API connectivity issues
-            - The request exceeded the 7-minute timeout limit
-
-            Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+          ERROR_OUTPUT: '${{ steps.gemini_pr_review.outputs.error }}'
+          SUMMARY_OUTPUT: '${{ steps.gemini_pr_review.outputs.summary }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-
+          # Build error message
+          MESSAGE="🤖 I encountered an error while reviewing this pull request.
+
+          "
+
+          # Add actual error if available
+          if [[ -n "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Error:**
+          \`\`\`
+          ${ERROR_OUTPUT}
+          \`\`\`
+
+          "
+          fi
+
+          # Add summary if available and different from error
+          if [[ -n "${SUMMARY_OUTPUT}" && "${SUMMARY_OUTPUT}" != "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Summary:**
+          ${SUMMARY_OUTPUT}
+
+          "
+          fi
+
+          MESSAGE+="Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+
+          **Configuration:**
+          - [Gemini CLI Setup Guide](.github/GEMINI_SETUP.md)
+          - [Official Documentation](https://github.com/google-github-actions/run-gemini-cli)"
+
           gh issue comment "${ISSUE_NUMBER}" \
             --body "${MESSAGE}" \
             --repo "${REPOSITORY}"

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -23,6 +23,8 @@ jobs:
     outputs:
       available_labels: '${{ steps.get_labels.outputs.available_labels }}'
       selected_labels: '${{ env.SELECTED_LABELS }}'
+      error: '${{ steps.gemini_analysis.outputs.error }}'
+      summary: '${{ steps.gemini_analysis.outputs.summary }}'
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -230,19 +232,39 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
-          MESSAGE: |-
-            🤖 I encountered an error while triaging this issue.
-
-            **Possible causes:**
-            - Missing or invalid API credentials (GEMINI_API_KEY or GOOGLE_API_KEY)
-            - Missing required configuration variables (GEMINI_MODEL, GEMINI_CLI_VERSION)
-            - Network or API connectivity issues
-            - No labels available in the repository
-            - The request exceeded the 7-minute timeout limit
-
-            Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+          ERROR_OUTPUT: '${{ needs.triage.outputs.error }}'
+          SUMMARY_OUTPUT: '${{ needs.triage.outputs.summary }}'
           REPOSITORY: '${{ github.repository }}'
         run: |-
+          # Build error message
+          MESSAGE="🤖 I encountered an error while triaging this issue.
+
+          "
+
+          # Add actual error if available
+          if [[ -n "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Error:**
+          \`\`\`
+          ${ERROR_OUTPUT}
+          \`\`\`
+
+          "
+          fi
+
+          # Add summary if available and different from error
+          if [[ -n "${SUMMARY_OUTPUT}" && "${SUMMARY_OUTPUT}" != "${ERROR_OUTPUT}" ]]; then
+            MESSAGE+="**Summary:**
+          ${SUMMARY_OUTPUT}
+
+          "
+          fi
+
+          MESSAGE+="Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+
+          **Configuration:**
+          - [Gemini CLI Setup Guide](.github/GEMINI_SETUP.md)
+          - [Official Documentation](https://github.com/google-github-actions/run-gemini-cli)"
+
           gh issue comment "${ISSUE_NUMBER}" \
             --body "${MESSAGE}" \
             --repo "${REPOSITORY}"


### PR DESCRIPTION
- Add 15-minute timeout to gemini-invoke workflow
- Add error reporting steps to all three Gemini workflows (invoke, review, triage)
- Workflows now post helpful error messages to issues/PRs when they fail
- Error messages include common causes and link to workflow logs
- Create comprehensive GEMINI_SETUP.md guide with:
  - Required secrets and variables documentation
  - Quick setup instructions
  - Troubleshooting section
  - Security notes

This fixes the issue where Gemini would acknowledge mentions but fail silently without reporting errors back to the user.

Closes #51