### PR TITLE
Publish RC release to NPM via changesets

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -35,7 +35,6 @@ jobs:
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
   release-candidate:


### PR DESCRIPTION
The workflow now also triggers on the changeset-release/main branch and publishes packages with the 'rc' tag to npm using OIDC provenance.