### PR TITLE
Remove max width constraint from prose div

### DIFF
--- a/packages/docs/astro/Layout.astro
+++ b/packages/docs/astro/Layout.astro
@@ -84,7 +84,7 @@ const entries: NavigationTree =
 <BaseLayout sidebarNavigation={entries}>
   <div class="grid grid-cols-12 gap-6 max-w-7xl mx-auto">
     <div class="col-span-12 xl:col-span-9">
-      <div class="prose max-w-none">
+      <div class="prose !max-w-none">
         <Breadcrumbs navigation={entries} />
         <TableOfContents links={headings} class="xl:hidden" />
         <slot />


### PR DESCRIPTION
The prose div was applying a max-width constraint that needed to be disabled. Added inline style to explicitly override the Tailwind Typography prose class max-width.