### PR TITLE
Add README files to shipyard packages

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,7 @@
+---
+'@levino/shipyard-base': patch
+'@levino/shipyard-blog': patch
+'@levino/shipyard-docs': patch
+---
+
+Each package now includes a README with installation instructions, basic usage examples, and links to the official documentation at shipyard.levinkeller.de.

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -1,0 +1,66 @@
+# @levino/shipyard-base
+
+Core package for [Shipyard](https://shipyard.levinkeller.de), a general-purpose page builder for Astro.
+
+## Installation
+
+```bash
+npm install @levino/shipyard-base
+```
+
+## Peer Dependencies
+
+- `astro` ^5.7
+- `tailwindcss` ^3
+- `daisyui` ^4
+- `@tailwindcss/typography` ^0.5.10
+
+## Basic Usage
+
+### Astro Integration
+
+```ts
+// astro.config.ts
+import shipyard from '@levino/shipyard-base'
+
+export default defineConfig({
+  integrations: [
+    shipyard({
+      title: 'My Site',
+      // ... configuration
+    }),
+  ],
+})
+```
+
+### Layouts
+
+```astro
+---
+import { Page } from '@levino/shipyard-base/layouts'
+---
+
+<Page title="My Page">
+  <p>Page content</p>
+</Page>
+```
+
+Available layouts: `Page`, `Splash`, `Footer`
+
+### Components
+
+```astro
+---
+import { SidebarNavigation, Breadcrumbs } from '@levino/shipyard-base/components'
+---
+```
+
+Available components: `Breadcrumbs`, `Footer`, `GlobalDesktopNavigation`, `LocalNavigation`, `SidebarElement`, `SidebarNavigation`, `TableOfContents`
+
+## Documentation
+
+For complete documentation and examples, visit [shipyard.levinkeller.de](https://shipyard.levinkeller.de).
+
+## License
+
+MIT

--- a/packages/blog/README.md
+++ b/packages/blog/README.md
@@ -1,0 +1,67 @@
+# @levino/shipyard-blog
+
+Blog plugin for [Shipyard](https://shipyard.levinkeller.de), a general-purpose page builder for Astro.
+
+## Installation
+
+```bash
+npm install @levino/shipyard-blog
+```
+
+## Peer Dependencies
+
+- `astro` ^5.15
+
+## Basic Usage
+
+### Astro Integration
+
+```ts
+// astro.config.ts
+import shipyardBlog from '@levino/shipyard-blog'
+
+export default defineConfig({
+  integrations: [
+    shipyardBlog({
+      blogSidebarCount: 5,
+      blogSidebarTitle: 'Recent posts',
+      postsPerPage: 10,
+      editUrl: 'https://github.com/user/repo/edit/main/blog',
+      showLastUpdateTime: true,
+      showLastUpdateAuthor: true,
+    }),
+  ],
+})
+```
+
+### Content Collection Schema
+
+```ts
+// content.config.ts
+import { defineCollection } from 'astro:content'
+import { blogSchema } from '@levino/shipyard-blog'
+
+const blog = defineCollection({
+  schema: blogSchema,
+})
+
+export const collections = { blog }
+```
+
+### Routes
+
+The integration automatically injects these routes:
+
+- `/blog` - Blog index
+- `/blog/page/[page]` - Paginated blog index
+- `/blog/[...slug]` - Individual blog posts
+
+With i18n enabled, routes are prefixed with `[locale]`.
+
+## Documentation
+
+For complete documentation and examples, visit [shipyard.levinkeller.de](https://shipyard.levinkeller.de).
+
+## License
+
+MIT

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,0 +1,73 @@
+# @levino/shipyard-docs
+
+Documentation plugin for [Shipyard](https://shipyard.levinkeller.de), a general-purpose page builder for Astro.
+
+## Installation
+
+```bash
+npm install @levino/shipyard-docs
+```
+
+## Peer Dependencies
+
+- `astro` ^5.15
+
+## Basic Usage
+
+### Astro Integration
+
+```ts
+// astro.config.ts
+import shipyardDocs from '@levino/shipyard-docs'
+
+export default defineConfig({
+  integrations: [
+    shipyardDocs({
+      routeBasePath: 'docs',
+      editUrl: 'https://github.com/user/repo/edit/main/docs',
+      showLastUpdateTime: true,
+      showLastUpdateAuthor: true,
+    }),
+  ],
+})
+```
+
+### Content Collection
+
+```ts
+// content.config.ts
+import { defineCollection } from 'astro:content'
+import { createDocsCollection } from '@levino/shipyard-docs'
+
+const docs = defineCollection(createDocsCollection('./docs'))
+
+export const collections = { docs }
+```
+
+### Multiple Documentation Instances
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  integrations: [
+    shipyardDocs({ routeBasePath: 'docs' }),
+    shipyardDocs({ routeBasePath: 'guides', collectionName: 'guides' }),
+  ],
+})
+```
+
+### Routes
+
+The integration automatically injects these routes:
+
+- `/[routeBasePath]/[...slug]` - Documentation pages
+
+With i18n enabled, routes are prefixed with `[locale]`.
+
+## Documentation
+
+For complete documentation and examples, visit [shipyard.levinkeller.de](https://shipyard.levinkeller.de).
+
+## License
+
+MIT


### PR DESCRIPTION
Add documentation for basic usage of @levino/shipyard-base, @levino/shipyard-blog, and @levino/shipyard-docs packages with links to the official documentation.