### PR TITLE
feat: increase Playwright workers for faster CI

### DIFF
--- a/apps/demos/i18n/playwright.config.ts
+++ b/apps/demos/i18n/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:4321',

--- a/apps/demos/single-language/playwright.config.ts
+++ b/apps/demos/single-language/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:4321',


### PR DESCRIPTION
Increases Playwright workers from 1 to 4 in CI for faster E2E test execution.

Closes #119

Generated with [Claude Code](https://claude.ai/code)