### PR TITLE
fix: use Markdown layout for pages with prose content

### DIFF
--- a/apps/demos/i18n/src/pages/en/about.md
+++ b/apps/demos/i18n/src/pages/en/about.md
@@ -1,5 +1,5 @@
 ---
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 title: About Metro Gardens
 description: Learn about our community garden's mission, history, and the dedicated team that makes it all possible.
 ---

--- a/apps/demos/i18n/src/pages/en/index.md
+++ b/apps/demos/i18n/src/pages/en/index.md
@@ -1,5 +1,5 @@
 ---
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 title: Metro Gardens Community Club
 locale: en
 description:

--- a/apps/demos/single-language/src/pages/about.md
+++ b/apps/demos/single-language/src/pages/about.md
@@ -1,7 +1,7 @@
 ---
 title: About Single Language Demo  
 description: Learn about this single-language shipyard demonstration
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 ---
 
 This is one of the demo applications for shipyard.

--- a/apps/demos/single-language/src/pages/index.md
+++ b/apps/demos/single-language/src/pages/index.md
@@ -1,7 +1,7 @@
 ---
 title: Welcome to Single Language Demo
 description: A demonstration of shipyard without internationalization
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 ---
 
 # Welcome to Single Language Demo

--- a/apps/docs/src/pages/en/about.md
+++ b/apps/docs/src/pages/en/about.md
@@ -1,5 +1,5 @@
 ---
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 title: shipyard
 locale: en
 description:

--- a/apps/docs/src/pages/en/index.md
+++ b/apps/docs/src/pages/en/index.md
@@ -1,5 +1,5 @@
 ---
-layout: '@levino/shipyard-base/layouts/Splash.astro'
+layout: '@levino/shipyard-base/layouts/Markdown.astro'
 title: 🚢 shipyard
 locale: en
 description:


### PR DESCRIPTION
Fixes #122

## Summary

- Changed 6 markdown pages from Splash layout to Markdown layout
- The Markdown layout applies the `prose` class needed for proper markdown styling
- All E2E tests pass

Generated with [Claude Code](https://claude.ai/code)