### PR TITLE
fix: update single language demo URL to single-locale

### DIFF
--- a/apps/docs/docs/de/index.md
+++ b/apps/docs/docs/de/index.md
@@ -78,7 +78,7 @@ Erkunde shipyards Features in Aktion mit unseren Demo-Seiten:
 
 | Demo | Beschreibung |
 |------|--------------|
-| **[Single Language](https://single-language.demos.shipyard.levinkeller.de)** | Basis-shipyard-Setup mit Doku und Blog |
+| **[Single Language](https://single-locale.demos.shipyard.levinkeller.de)** | Basis-shipyard-Setup mit Doku und Blog |
 | **[Internationalisierung (i18n)](https://i18n.demos.shipyard.levinkeller.de)** | Mehrsprachige Seite mit Locale-basiertem Routing |
 | **[Server-Modus](https://server-mode.demos.shipyard.levinkeller.de)** | Server-Side Rendering (SSR) mit On-Demand-Seitengenerierung |
 

--- a/apps/docs/docs/en/index.md
+++ b/apps/docs/docs/en/index.md
@@ -78,7 +78,7 @@ Explore shipyard's features in action with our demo sites:
 
 | Demo | Description |
 |------|-------------|
-| **[Single Language](https://single-language.demos.shipyard.levinkeller.de)** | Basic shipyard setup with docs and blog |
+| **[Single Language](https://single-locale.demos.shipyard.levinkeller.de)** | Basic shipyard setup with docs and blog |
 | **[Internationalization (i18n)](https://i18n.demos.shipyard.levinkeller.de)** | Multi-language site with locale-based routing |
 | **[Server Mode](https://server-mode.demos.shipyard.levinkeller.de)** | Server-side rendering (SSR) with on-demand page generation |
 


### PR DESCRIPTION
Updated the single language demo URL from `single-language.demos.shipyard.levinkeller.de` to `single-locale.demos.shipyard.levinkeller.de` in the documentation.

Closes #125

Generated with [Claude Code](https://claude.ai/code)