### PR TITLE
Add horizontal scroll to markdown tables

### DIFF
--- a/packages/base/src/globals.css
+++ b/packages/base/src/globals.css
@@ -3,3 +3,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .prose :where(table) {
+    @apply block overflow-x-auto;
+  }
+}


### PR DESCRIPTION
Tables in prose containers now have overflow-x-auto to handle wide tables gracefully on mobile devices.