### PR TITLE
chore: add package metadata for Astro integrations directory

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,20 @@
 {
   "name": "@levino/shipyard-base",
   "version": "0.5.11",
+  "description": "Core layouts, components, and configuration for shipyard - a composable page builder for Astro",
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "withastro",
+    "frameworks",
+    "documentation",
+    "blog",
+    "tailwind",
+    "daisyui"
+  ],
+  "author": "Levin Keller",
+  "license": "MIT",
+  "homepage": "https://shipyard.levinkeller.de",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@levino/shipyard-blog",
   "version": "0.5.1",
-  "description": "",
+  "description": "Blog plugin for shipyard with pagination, sidebar, and git metadata",
   "type": "module",
   "main": "src/index.ts",
   "exports": {
@@ -13,9 +13,17 @@
     "astro",
     "src"
   ],
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "withastro",
+    "frameworks",
+    "blog",
+    "markdown"
+  ],
+  "author": "Levin Keller",
+  "license": "MIT",
+  "homepage": "https://shipyard.levinkeller.de",
   "dependencies": {
     "@levino/shipyard-base": "^0.5.9"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,15 +1,25 @@
 {
   "name": "@levino/shipyard-docs",
   "version": "0.5.2",
-  "description": "",
+  "description": "Documentation plugin for shipyard with automatic sidebar, pagination, and git metadata",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
     "test:unit": "vitest run"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "withastro",
+    "frameworks",
+    "documentation",
+    "docs",
+    "sidebar",
+    "markdown"
+  ],
+  "author": "Levin Keller",
+  "license": "MIT",
+  "homepage": "https://shipyard.levinkeller.de",
   "peerDependencies": {
     "astro": "^5.15"
   },


### PR DESCRIPTION
## Summary

Add keywords and metadata to all shipyard packages so they appear in the [Astro Integrations Directory](https://astro.build/integrations/).

## Changes

All three packages now include:
- `keywords`: `astro-integration`, `withastro`, etc.
- `description`: Clear package description
- `author`: Levin Keller
- `license`: MIT
- `homepage`: https://shipyard.levinkeller.de

The Astro integrations library automatically pulls packages with these keywords weekly.