### PR TITLE
feat: add Ralph Wiggum loop for autonomous task execution

### DIFF
--- a/.claude/commands/gppr.md
+++ b/.claude/commands/gppr.md
@@ -1,0 +1,1 @@
+commit, push and open a pr

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ gha-creds-*.json
 # Playwright
 playwright-report/
 test-results/
+
+# Ralph Wiggum session history (local only)
+ralph/history.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "shipyard-philosophy",
+  "name": "shipyard",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -29247,6 +29247,7 @@
     "packages/base": {
       "name": "@levino/shipyard-base",
       "version": "0.5.11",
+      "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",
         "ramda": "^0.31",
@@ -29968,7 +29969,7 @@
     "packages/blog": {
       "name": "@levino/shipyard-blog",
       "version": "0.5.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@levino/shipyard-base": "^0.5.9"
       },
@@ -29982,7 +29983,7 @@
     "packages/docs": {
       "name": "@levino/shipyard-docs",
       "version": "0.5.2",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@levino/shipyard-base": "^0.5.11",
         "effect": "^3.12.5",

--- a/ralph/PROMPT.md
+++ b/ralph/PROMPT.md
@@ -1,0 +1,86 @@
+# Ralph Session Instructions
+
+You are operating in a Ralph Wiggum loop. Each session you will:
+
+1. **Read State**: Load the task list and history
+2. **Pick Task**: Select the highest priority pending task (or continue an in_progress task)
+3. **Work**: Make incremental progress on the task
+4. **Update State**: Update tasks.json and append to history.md
+5. **Commit**: Commit your changes with a descriptive message
+6. **Exit**: End session cleanly so the loop can restart
+
+## Your Workflow
+
+### Step 1: Load Context
+
+Read these files:
+- `ralph/tasks.json` - Current task list
+- `ralph/history.md` - Recent session history (last 5 sessions)
+- Recent git log (last 10 commits)
+
+### Step 2: Select Task
+
+Use your judgment to pick the **best** task to work on now. Consider:
+
+1. **In-progress tasks first**: If a task is already `in_progress`, continue and complete it
+2. **Dependencies**: Some tasks depend on others - do prerequisites first
+3. **Priority**: Higher priority tasks are generally more important
+4. **Logical ordering**: What makes sense to build first? (e.g., core infrastructure before features that use it)
+5. **Context from history**: What was recently worked on? Does something naturally follow?
+
+If no pending/in_progress tasks remain, report completion and exit.
+
+### Step 3: Work on Task - COMPLETE IT FULLY
+
+- Update task status to `in_progress` in tasks.json
+- **Complete the task fully** - do not leave it half-done
+- Follow the project's coding standards (see CLAUDE.md)
+- Run tests to verify your work
+- Only mark as `blocked` if you genuinely cannot proceed (missing info, external dependency, etc.)
+
+### Step 4: Update State
+
+After completing work:
+- Update task status in `ralph/tasks.json`:
+  - `completed` if done (set completedAt to current timestamp)
+  - `in_progress` if more work needed
+  - `blocked` if stuck
+- Add notes about what was done
+- Append session summary to `ralph/history.md`
+
+### Step 5: Commit Changes
+
+- Stage and commit all changes
+- Use descriptive commit messages
+- Reference the task ID in the commit message
+
+### Step 6: Exit
+
+Print "RALPH_SESSION_COMPLETE" on its own line when done. This signals the loop to restart.
+
+## Important Rules
+
+- **One task, completed fully**: Pick one task and finish it completely before the session ends
+- **Use judgment for task selection**: Consider dependencies, logical ordering, and what makes sense - not just priority numbers
+- **Never leave tasks half-done**: If you start a task, finish it. Only mark as `blocked` if truly stuck.
+- **Always commit**: Leave the codebase in a clean, working state
+- **Run tests**: Verify your changes work before committing
+- **Update history**: Document what you did for future sessions
+
+## Example Session Output
+
+```
+Reading ralph/tasks.json...
+Found 3 pending tasks.
+Selecting task: fix-footer-alignment (priority: high)
+Updating task status to in_progress...
+
+Working on task...
+[... work happens ...]
+
+Task completed. Updating tasks.json...
+Appending to history.md...
+Committing changes...
+
+RALPH_SESSION_COMPLETE
+```

--- a/ralph/ralph.sh
+++ b/ralph/ralph.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Ralph Wiggum Loop
+# Continuously runs Claude sessions to work through tasks
+#
+# Usage: ./ralph/ralph.sh [options]
+#   --interactive  Run one interactive session (you can talk to Claude)
+#   --once         Run one autonomous session, then exit
+#   --dry-run      Print what would be run without executing
+#   --delay N      Wait N seconds between sessions (default: 5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+DRY_RUN=false
+RUN_ONCE=false
+INTERACTIVE=false
+DELAY=5
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --once)
+      RUN_ONCE=true
+      shift
+      ;;
+    --interactive)
+      INTERACTIVE=true
+      RUN_ONCE=true  # Interactive always runs once
+      shift
+      ;;
+    --delay)
+      DELAY="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+  echo -e "${BLUE}[RALPH]${NC} $1"
+}
+
+log_success() {
+  echo -e "${GREEN}[RALPH]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[RALPH]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[RALPH]${NC} $1"
+}
+
+# Check for pending tasks
+check_pending_tasks() {
+  local tasks_file="$SCRIPT_DIR/tasks.json"
+  if [[ ! -f "$tasks_file" ]]; then
+    log_error "tasks.json not found"
+    return 1
+  fi
+
+  # Count pending and in_progress tasks
+  local count
+  count=$(jq '[.tasks[] | select(.status == "pending" or .status == "in_progress")] | length' "$tasks_file")
+
+  if [[ "$count" -eq 0 ]]; then
+    log_success "All tasks completed!"
+    return 1
+  fi
+
+  log_info "Found $count pending/in_progress tasks"
+  return 0
+}
+
+# Run a single Claude session
+run_session() {
+  local session_num=$1
+  local prompt_file="$SCRIPT_DIR/PROMPT.md"
+
+  log_info "Starting session #$session_num"
+  log_info "$(date '+%Y-%m-%d %H:%M:%S')"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$INTERACTIVE" == "true" ]]; then
+      log_warn "[DRY RUN] Would execute: claude --prompt-file $prompt_file"
+    else
+      log_warn "[DRY RUN] Would execute: cat $prompt_file | claude --print"
+    fi
+    return 0
+  fi
+
+  cd "$REPO_ROOT"
+
+  if [[ "$INTERACTIVE" == "true" ]]; then
+    # Interactive mode - user can talk to Claude
+    log_info "Starting interactive session. You can talk to Claude."
+    log_info "Claude will read the Ralph prompt and work on tasks."
+    echo ""
+    if claude --prompt-file "$prompt_file"; then
+      log_success "Interactive session completed"
+      return 0
+    else
+      log_error "Interactive session failed"
+      return 1
+    fi
+  else
+    # Autonomous mode - pipe prompt to Claude
+    if cat "$prompt_file" | claude --print; then
+      log_success "Session #$session_num completed successfully"
+      return 0
+    else
+      log_error "Session #$session_num failed"
+      return 1
+    fi
+  fi
+}
+
+# Main loop
+main() {
+  log_info "Ralph Wiggum Loop starting..."
+  log_info "Repository: $REPO_ROOT"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN MODE - no commands will be executed"
+  fi
+
+  if [[ "$INTERACTIVE" == "true" ]]; then
+    log_info "Interactive mode - you will be able to talk to Claude"
+  elif [[ "$RUN_ONCE" == "true" ]]; then
+    log_info "Single autonomous session mode"
+  else
+    log_info "Continuous loop mode (delay: ${DELAY}s between sessions)"
+  fi
+
+  local session=0
+
+  while true; do
+    session=$((session + 1))
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Check if there are tasks to work on
+    if ! check_pending_tasks; then
+      log_info "No more tasks. Exiting."
+      break
+    fi
+
+    # Run the session
+    if ! run_session "$session"; then
+      log_error "Session failed. Waiting before retry..."
+      sleep "$DELAY"
+      continue
+    fi
+
+    # Exit if running once
+    if [[ "$RUN_ONCE" == "true" ]]; then
+      log_info "Single session complete. Exiting."
+      break
+    fi
+
+    # Wait before next session
+    log_info "Waiting ${DELAY}s before next session..."
+    sleep "$DELAY"
+  done
+
+  log_success "Ralph Wiggum Loop finished"
+}
+
+main

--- a/ralph/tasks.json
+++ b/ralph/tasks.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "./tasks.schema.json",
+  "version": 1,
+  "tasks": [
+    {
+      "id": "example-task-1",
+      "title": "Example: Fix a bug in component X",
+      "description": "Detailed description of what needs to be done",
+      "status": "pending",
+      "priority": "high",
+      "createdAt": "2026-01-06T00:00:00Z",
+      "completedAt": null,
+      "notes": []
+    }
+  ]
+}

--- a/ralph/tasks.schema.json
+++ b/ralph/tasks.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Ralph Tasks",
+  "type": "object",
+  "required": ["version", "tasks"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Schema version"
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "status", "priority", "createdAt"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique task identifier (kebab-case)"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short task title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of what needs to be done"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "in_progress", "completed", "blocked"],
+            "description": "Current task status"
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"],
+            "description": "Task priority level"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the task was created"
+          },
+          "completedAt": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "When the task was completed"
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Progress notes and observations"
+          },
+          "blockedBy": {
+            "type": "string",
+            "description": "ID of task blocking this one (use when stuck)"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "IDs of tasks that must be completed before this one can start"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a bash-based loop (`ralph/ralph.sh`) that repeatedly calls Claude to work through a task list
- Implements task tracking via `ralph/tasks.json` with status, priority, and dependency support
- Includes instructions for Claude in `ralph/PROMPT.md` to guide each session
- Supports multiple modes: continuous loop, single autonomous session, interactive session, and dry run

Inspired by:
- [Anthropic's blog post on effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
- [The Ralph Wiggum pattern](https://ghuntley.com/ralph/)

## Test plan

- [ ] Run `./ralph/ralph.sh --dry-run` to verify script logic
- [ ] Run `./ralph/ralph.sh --interactive` to test interactive mode
- [ ] Add tasks to `ralph/tasks.json` and verify Claude processes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)