### PR TITLE
fix: update docs navigation link in single-locale demo

### DIFF
--- a/apps/demos/single-locale/astro.config.mjs
+++ b/apps/demos/single-locale/astro.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
       navigation: {
         docs: {
           label: 'Documentation',
-          href: '/docs/index',
+          href: '/docs/markdown-features',
         },
         blog: {
           label: 'Blog',


### PR DESCRIPTION
Change docs navigation href from /docs/index to /docs/markdown-features since /docs does not exist as a route.

Fixes #152

Generated with [Claude Code](https://claude.ai/code)