### PR TITLE
Fix versioning strategy for 0.x releases

### DIFF
--- a/.changeset/broken-links-feature.md
+++ b/.changeset/broken-links-feature.md
@@ -1,5 +1,5 @@
 ---
-'@levino/shipyard-base': minor
+'@levino/shipyard-base': patch
 ---
 
 You can now enable broken link detection during production builds. Shipyard automatically scans your built HTML files for internal links that point to non-existent pages, helping you catch issues before deploying.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,9 +159,8 @@ Documentation features:
    - Modifying existing functionality that affects users
    - The docs app contains the actual shipyard documentation, not just demos
 8. **Changesets**: Create a changeset using `npx changeset` when making changes that affect packages:
-   - Use patch version for bug fixes and minor improvements (especially in 0.x.y versions)
-   - Use minor version for new features (when above 1.0.0)
-   - Use major version for breaking changes (when above 1.0.0)
+   - **0.x.y versioning** (current phase): Use `patch` for everything (bug fixes, improvements, new features). Only use `minor` for breaking changes.
+   - **1.x.y versioning** (post-1.0): Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
    - **Write user-centric descriptions**: Focus on what users can now do, not what code was changed
      - ✅ Good: "You can now host multiple documentation sections with custom URL paths"
      - ❌ Bad: "Added `DocsConfig` interface with `routeBasePath` option"


### PR DESCRIPTION
- Change broken-links-feature changeset from minor to patch
- Update CLAUDE.md to clarify 0.x versioning strategy: use patch for everything except breaking changes (which use minor)