### PR TITLE
fix: auto-register remark plugins for admonitions

### DIFF
--- a/.changeset/fix-admonitions-auto-register.md
+++ b/.changeset/fix-admonitions-auto-register.md
@@ -1,0 +1,5 @@
+---
+"@levino/shipyard-base": patch
+---
+
+Admonitions and other markdown features now work out-of-the-box without manual configuration. The shipyard integration automatically registers the required remark plugins (remarkDirective, remarkAdmonitions, remarkNpm2Yarn), so you no longer need to add them to your Astro config.

--- a/apps/demos/single-locale/astro.config.mjs
+++ b/apps/demos/single-locale/astro.config.mjs
@@ -2,11 +2,6 @@
 
 import tailwind from '@astrojs/tailwind'
 import shipyard from '@levino/shipyard-base'
-import {
-  remarkAdmonitions,
-  remarkDirective,
-  remarkNpm2Yarn,
-} from '@levino/shipyard-base/remark'
 import { shipyardCodeBlockTransformers } from '@levino/shipyard-base/shiki'
 import shipyardDocs from '@levino/shipyard-docs'
 import { defineConfig } from 'astro/config'
@@ -16,7 +11,6 @@ import shipyardBlog from '../../../packages/blog/src/index.ts'
 export default defineConfig({
   // No i18n configuration - single language site
   markdown: {
-    remarkPlugins: [remarkDirective, remarkAdmonitions, remarkNpm2Yarn],
     shikiConfig: {
       transformers: shipyardCodeBlockTransformers(),
     },

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,5 +1,8 @@
 import { fileURLToPath } from 'node:url'
 import type { AstroIntegration } from 'astro'
+import remarkDirective from 'remark-directive'
+import { remarkAdmonitions } from './remark/remarkAdmonitions'
+import { remarkNpm2Yarn } from './remark/remarkNpm2Yarn'
 import type { Config } from './schemas/config'
 import { checkLinks, reportBrokenLinks } from './tools/linkChecker'
 
@@ -39,6 +42,9 @@ export default (config: Config): AstroIntegration => {
         } as Record<string, string | undefined>
 
         updateConfig({
+          markdown: {
+            remarkPlugins: [remarkDirective, remarkAdmonitions, remarkNpm2Yarn],
+          },
           vite: {
             plugins: [
               {

--- a/packages/base/src/remark/index.ts
+++ b/packages/base/src/remark/index.ts
@@ -1,17 +1,9 @@
 /**
  * Remark plugins for shipyard markdown processing.
  *
- * @example
- * ```ts
- * import remarkDirective from 'remark-directive'
- * import { remarkAdmonitions } from '@levino/shipyard-base/remark'
- *
- * export default defineConfig({
- *   markdown: {
- *     remarkPlugins: [remarkDirective, remarkAdmonitions],
- *   },
- * })
- * ```
+ * Note: These plugins are automatically registered by the shipyard integration.
+ * You don't need to configure them manually. They are exported here for
+ * advanced use cases where you need direct access to the plugins.
  */
 
 // Re-export remark-directive for convenience

--- a/packages/base/src/remark/remarkAdmonitions.ts
+++ b/packages/base/src/remark/remarkAdmonitions.ts
@@ -41,7 +41,10 @@ const getDefaultTitle = (type: AdmonitionType): string => {
 /**
  * Remark plugin to transform container directives into admonitions.
  *
- * This plugin works with remark-directive to transform:
+ * This plugin is automatically registered by the shipyard integration.
+ * You don't need to configure it manually.
+ *
+ * It works with remark-directive to transform:
  * ```markdown
  * :::note
  * This is a note
@@ -53,18 +56,6 @@ const getDefaultTitle = (type: AdmonitionType): string => {
  * ```
  *
  * Into properly structured admonition HTML.
- *
- * @example
- * ```ts
- * import remarkDirective from 'remark-directive'
- * import { remarkAdmonitions } from '@levino/shipyard-base/remark'
- *
- * export default defineConfig({
- *   markdown: {
- *     remarkPlugins: [remarkDirective, remarkAdmonitions],
- *   },
- * })
- * ```
  */
 export const remarkAdmonitions: Plugin<[], Root> = () => {
   return (tree: Root) => {


### PR DESCRIPTION
Fixes #164

The shipyard integration now automatically registers the required remark plugins (remarkDirective, remarkAdmonitions, remarkNpm2Yarn), so admonitions work out-of-the-box without manual configuration.

Generated with [Claude Code](https://claude.ai/claude-code)