### PR TITLE
docs: update documentation to reflect Tailwind CSS 4 migration

### DIFF
--- a/apps/docs/docs/de/base-package.md
+++ b/apps/docs/docs/de/base-package.md
@@ -24,32 +24,13 @@ npm install tailwindcss daisyui @tailwindcss/typography
 | Paket | Version |
 |-------|---------|
 | `astro` | ^5.7 |
-| `tailwindcss` | ^3 |
-| `daisyui` | ^4 |
+| `tailwindcss` | ^4 |
+| `daisyui` | ^5 |
 | `@tailwindcss/typography` | ^0.5.10 |
 
 ### Tailwind-Konfiguration
 
-Damit Tailwind die in shipyard-Komponenten verwendeten Klassen korrekt erkennt, musst du die Paketpfade zum `content`-Array in deiner `tailwind.config.mjs` hinzufügen:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // Füge dies hinzu, um shipyard-base Komponenten-Styles einzuschließen
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... Rest deiner Konfiguration
-}
-```
-
-Dies stellt sicher, dass Tailwind die shipyard-Komponentendateien scannt und alle notwendigen CSS-Klassen in deinen Build einschließt.
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
 
 ## Konfiguration
 

--- a/apps/docs/docs/de/blog-package.md
+++ b/apps/docs/docs/de/blog-package.md
@@ -19,29 +19,7 @@ Erfordert dass `@levino/shipyard-base` installiert und konfiguriert ist.
 
 ### Tailwind-Konfiguration
 
-Damit Tailwind die in shipyard-blog-Komponenten verwendeten Klassen korrekt erkennt, musst du den Paketpfad zum `content`-Array in deiner `tailwind.config.mjs` hinzufügen:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // shipyard-base einschließen (erforderlich)
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-    // shipyard-blog einschließen
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-blog')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... Rest deiner Konfiguration
-}
-```
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
 
 ## Schnellstart
 
@@ -50,11 +28,18 @@ export default {
 ```javascript
 import shipyard from '@levino/shipyard-base'
 import shipyardBlog from '@levino/shipyard-blog'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
+import appCss from './src/styles/app.css?url'
+
 export default defineConfig({
+  vite: {
+    plugins: [tailwindcss()],
+  },
   integrations: [
     shipyard({
+      css: appCss,
       brand: 'Meine Seite',
       title: 'Meine Seite',
       tagline: 'Ein Blog',

--- a/apps/docs/docs/de/docs-package.md
+++ b/apps/docs/docs/de/docs-package.md
@@ -19,29 +19,7 @@ Erfordert dass `@levino/shipyard-base` installiert und konfiguriert ist.
 
 ### Tailwind-Konfiguration
 
-Damit Tailwind die in shipyard-docs-Komponenten verwendeten Klassen korrekt erkennt, musst du den Paketpfad zum `content`-Array in deiner `tailwind.config.mjs` hinzufügen:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // shipyard-base einschließen (erforderlich)
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-    // shipyard-docs einschließen
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-docs')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... Rest deiner Konfiguration
-}
-```
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
 
 ## Schnellstart
 
@@ -50,11 +28,18 @@ export default {
 ```javascript
 import shipyard from '@levino/shipyard-base'
 import shipyardDocs from '@levino/shipyard-docs'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
+import appCss from './src/styles/app.css?url'
+
 export default defineConfig({
+  vite: {
+    plugins: [tailwindcss()],
+  },
   integrations: [
     shipyard({
+      css: appCss,
       brand: 'Meine Seite',
       title: 'Meine Seite',
       tagline: 'Dokumentation',

--- a/apps/docs/docs/en/base-package.md
+++ b/apps/docs/docs/en/base-package.md
@@ -24,32 +24,13 @@ npm install tailwindcss daisyui @tailwindcss/typography
 | Package | Version |
 |---------|---------|
 | `astro` | ^5.7 |
-| `tailwindcss` | ^3 |
-| `daisyui` | ^4 |
+| `tailwindcss` | ^4 |
+| `daisyui` | ^5 |
 | `@tailwindcss/typography` | ^0.5.10 |
 
 ### Tailwind Configuration
 
-For Tailwind to correctly pick up the classes used in shipyard components, you need to add the package paths to the `content` array in your `tailwind.config.mjs`:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // Add this to include shipyard-base component styles
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... rest of your config
-}
-```
-
-This ensures that Tailwind scans the shipyard component files and includes all necessary CSS classes in your build.
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
 
 ## Configuration
 

--- a/apps/docs/docs/en/blog-package.md
+++ b/apps/docs/docs/en/blog-package.md
@@ -19,29 +19,7 @@ Requires `@levino/shipyard-base` to be installed and configured.
 
 ### Tailwind Configuration
 
-For Tailwind to correctly pick up the classes used in shipyard-blog components, you need to add the package path to the `content` array in your `tailwind.config.mjs`:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // Include shipyard-base (required)
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-    // Include shipyard-blog
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-blog')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... rest of your config
-}
-```
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
 
 ## Quick Start
 
@@ -50,11 +28,18 @@ export default {
 ```javascript
 import shipyard from '@levino/shipyard-base'
 import shipyardBlog from '@levino/shipyard-blog'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
+import appCss from './src/styles/app.css?url'
+
 export default defineConfig({
+  vite: {
+    plugins: [tailwindcss()],
+  },
   integrations: [
     shipyard({
+      css: appCss,
       brand: 'My Site',
       title: 'My Site',
       tagline: 'A blog',

--- a/apps/docs/docs/en/docs-package.md
+++ b/apps/docs/docs/en/docs-package.md
@@ -19,29 +19,7 @@ Requires `@levino/shipyard-base` to be installed and configured.
 
 ### Tailwind Configuration
 
-For Tailwind to correctly pick up the classes used in shipyard-docs components, you need to add the package path to the `content` array in your `tailwind.config.mjs`:
-
-```javascript
-const path = require('node:path')
-
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: [
-    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-    // Include shipyard-base (required)
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-base')),
-      '../astro/**/*.astro',
-    ),
-    // Include shipyard-docs
-    path.join(
-      path.dirname(require.resolve('@levino/shipyard-docs')),
-      '../astro/**/*.astro',
-    ),
-  ],
-  // ... rest of your config
-}
-```
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
 
 ## Quick Start
 
@@ -50,11 +28,18 @@ export default {
 ```javascript
 import shipyard from '@levino/shipyard-base'
 import shipyardDocs from '@levino/shipyard-docs'
+import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 
+import appCss from './src/styles/app.css?url'
+
 export default defineConfig({
+  vite: {
+    plugins: [tailwindcss()],
+  },
   integrations: [
     shipyard({
+      css: appCss,
       brand: 'My Site',
       title: 'My Site',
       tagline: 'Documentation',


### PR DESCRIPTION
Update all package documentation files (base-package, docs-package, blog-package) in both English and German to:

- Update peer dependencies table: tailwindcss ^3 → ^4, daisyui ^4 → ^5
- Replace outdated Tailwind 3 configuration sections with reference to the Tailwind CSS Setup guide
- Update Quick Start sections to include the css: appCss property and @tailwindcss/vite plugin configuration

Fixes #176

Generated with [Claude Code](https://claude.ai/code)