### PR TITLE
fix(blog): resolve circular dependency warning in tags module

### DIFF
--- a/.changeset/fix-circular-dependency.md
+++ b/.changeset/fix-circular-dependency.md
@@ -1,0 +1,5 @@
+---
+'@levino/shipyard-blog': patch
+---
+
+Fixed circular dependency warning in blog package that caused Vite warnings during build about exports being "reexported through module while both modules are dependencies of each other".

--- a/packages/blog/astro/BlogTagPage.astro
+++ b/packages/blog/astro/BlogTagPage.astro
@@ -17,7 +17,8 @@ import {
   toLower,
   uniq,
 } from 'ramda'
-import { getReadingTime, getTagDescription, getTagLabel } from '../src/index'
+import { getReadingTime } from '../src/index'
+import { getTagDescription, getTagLabel } from '../src/tags'
 import BlogReadingTime from './BlogReadingTime.astro'
 import BlogTags from './BlogTags.astro'
 import Layout from './Layout.astro'

--- a/packages/blog/astro/BlogTagsIndex.astro
+++ b/packages/blog/astro/BlogTagsIndex.astro
@@ -8,7 +8,7 @@ import blogConfig from 'virtual:shipyard-blog/config'
 import tagsMap from 'virtual:shipyard-blog/tags'
 import type { GetStaticPaths } from 'astro'
 import { groupBy, map, pipe, prop, reverse, sortBy, toPairs } from 'ramda'
-import { getTagDescription, getTagLabel, getTagPermalink } from '../src/index'
+import { getTagDescription, getTagLabel, getTagPermalink } from '../src/tags'
 import Layout from './Layout.astro'
 
 const { includeDraftsInDev, routeBasePath } = blogConfig

--- a/packages/blog/src/index.ts
+++ b/packages/blog/src/index.ts
@@ -10,13 +10,14 @@ export { getEditUrl, getGitMetadata } from './gitMetadata'
 export type { ReadingTime } from './readingTime'
 export { getReadingTime } from './readingTime'
 // Re-export tag utilities
-export type { TagsMap } from './tags'
+export type { Tag, TagsMap } from './tags'
 export {
   getTagDescription,
   getTagLabel,
   getTagMetadata,
   getTagPermalink,
   loadTagsMap,
+  tagSchema,
 } from './tags'
 
 /**
@@ -46,26 +47,6 @@ export const authorSchema = z.object({
 })
 
 export type Author = z.infer<typeof authorSchema>
-
-/**
- * Schema for tag definition in tags.yml file.
- */
-export const tagSchema = z.object({
-  /**
-   * Display label for the tag. If not provided, uses the tag key.
-   */
-  label: z.string().optional(),
-  /**
-   * Description of the tag for the tag page.
-   */
-  description: z.string().optional(),
-  /**
-   * Custom permalink for the tag. If not provided, uses the tag key.
-   */
-  permalink: z.string().optional(),
-})
-
-export type Tag = z.infer<typeof tagSchema>
 
 export const blogSchema = z.object({
   date: z.date(),

--- a/packages/blog/src/tags.ts
+++ b/packages/blog/src/tags.ts
@@ -1,6 +1,26 @@
 import { existsSync, readFileSync } from 'node:fs'
+import { z } from 'astro/zod'
 import { parse as parseYaml } from 'yaml'
-import { type Tag, tagSchema } from './index'
+
+/**
+ * Schema for tag definition in tags.yml file.
+ */
+export const tagSchema = z.object({
+  /**
+   * Display label for the tag. If not provided, uses the tag key.
+   */
+  label: z.string().optional(),
+  /**
+   * Description of the tag for the tag page.
+   */
+  description: z.string().optional(),
+  /**
+   * Custom permalink for the tag. If not provided, uses the tag key.
+   */
+  permalink: z.string().optional(),
+})
+
+export type Tag = z.infer<typeof tagSchema>
 
 export type TagsMap = Record<string, Tag>
 
@@ -30,15 +50,15 @@ export const loadTagsMap = (tagsMapPath?: string): TagsMap => {
   }
 
   // Validate each tag against the schema
-  const tagsMap: TagsMap = {}
+  const result: TagsMap = {}
   for (const [key, value] of Object.entries(rawData)) {
-    const result = tagSchema.safeParse(value)
-    if (result.success) {
-      tagsMap[key.toLowerCase()] = result.data
+    const parsed = tagSchema.safeParse(value)
+    if (parsed.success) {
+      result[key.toLowerCase()] = parsed.data
     }
   }
 
-  return tagsMap
+  return result
 }
 
 /**


### PR DESCRIPTION
Closes #182

## Summary

Fixes circular dependency warnings during build by restructuring imports in the blog package.

## Changes

- Moved `tagSchema` and `Tag` type from `index.ts` to `tags.ts`
- Updated Astro components to import tag utilities directly from `tags.ts`

Generated with [Claude Code](https://claude.ai/claude-code)