### PR TITLE
fix: correct broken relative links to tailwind-setup guide

### DIFF
--- a/apps/docs/docs/de/base-package.md
+++ b/apps/docs/docs/de/base-package.md
@@ -30,7 +30,7 @@ npm install tailwindcss daisyui @tailwindcss/typography
 
 ### Tailwind-Konfiguration
 
-shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](../guides/tailwind-setup).
 
 ## Konfiguration
 

--- a/apps/docs/docs/de/blog-package.md
+++ b/apps/docs/docs/de/blog-package.md
@@ -19,7 +19,7 @@ Erfordert dass `@levino/shipyard-base` installiert und konfiguriert ist.
 
 ### Tailwind-Konfiguration
 
-shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](../guides/tailwind-setup).
 
 ## Schnellstart
 

--- a/apps/docs/docs/de/docs-package.md
+++ b/apps/docs/docs/de/docs-package.md
@@ -19,7 +19,7 @@ Erfordert dass `@levino/shipyard-base` installiert und konfiguriert ist.
 
 ### Tailwind-Konfiguration
 
-shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](./guides/tailwind-setup).
+shipyard verwendet Tailwind CSS 4, das einen CSS-basierten Konfigurationsansatz nutzt. Für detaillierte Setup-Anweisungen siehe die [Tailwind CSS Setup-Anleitung](../guides/tailwind-setup).
 
 ## Schnellstart
 

--- a/apps/docs/docs/de/getting-started.md
+++ b/apps/docs/docs/de/getting-started.md
@@ -78,7 +78,7 @@ Erstelle `src/styles/app.css` mit der Tailwind CSS 4 Konfiguration:
 @plugin "@tailwindcss/typography";
 ```
 
-**Wichtig:** Die shipyard-Pakete enthalten automatisch die nötigen `@source`-Direktiven, damit Tailwind die CSS-Klassen in den Komponenten erkennt. Siehe [Tailwind CSS Setup](./guides/tailwind-setup) für detaillierte Konfigurationsoptionen und Fehlerbehebung.
+**Wichtig:** Die shipyard-Pakete enthalten automatisch die nötigen `@source`-Direktiven, damit Tailwind die CSS-Klassen in den Komponenten erkennt. Siehe [Tailwind CSS Setup](../guides/tailwind-setup) für detaillierte Konfigurationsoptionen und Fehlerbehebung.
 
 ### Astro-Konfiguration
 
@@ -375,7 +375,7 @@ Wenn Komponenten ungestylt oder kaputt erscheinen:
 
 3. **Prüfe css-Konfiguration** — Stelle sicher, dass `astro.config.mjs` dein CSS mit `?url` importiert und an shipyard übergibt
 
-Siehe [Tailwind CSS Setup](./guides/tailwind-setup) für detaillierte Fehlerbehebung.
+Siehe [Tailwind CSS Setup](../guides/tailwind-setup) für detaillierte Fehlerbehebung.
 
 ### Dokumentationsseiten geben 404 zurück
 

--- a/apps/docs/docs/en/base-package.md
+++ b/apps/docs/docs/en/base-package.md
@@ -30,7 +30,7 @@ npm install tailwindcss daisyui @tailwindcss/typography
 
 ### Tailwind Configuration
 
-shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](../guides/tailwind-setup).
 
 ## Configuration
 

--- a/apps/docs/docs/en/blog-package.md
+++ b/apps/docs/docs/en/blog-package.md
@@ -19,7 +19,7 @@ Requires `@levino/shipyard-base` to be installed and configured.
 
 ### Tailwind Configuration
 
-shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](../guides/tailwind-setup).
 
 ## Quick Start
 

--- a/apps/docs/docs/en/docs-package.md
+++ b/apps/docs/docs/en/docs-package.md
@@ -19,7 +19,7 @@ Requires `@levino/shipyard-base` to be installed and configured.
 
 ### Tailwind Configuration
 
-shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](./guides/tailwind-setup).
+shipyard uses Tailwind CSS 4, which uses a CSS-based configuration approach. For detailed setup instructions, see the [Tailwind CSS Setup guide](../guides/tailwind-setup).
 
 ## Quick Start
 

--- a/apps/docs/docs/en/getting-started.md
+++ b/apps/docs/docs/en/getting-started.md
@@ -78,7 +78,7 @@ Create `src/styles/app.css` with the Tailwind CSS 4 configuration:
 @plugin "@tailwindcss/typography";
 ```
 
-The shipyard packages include built-in `@source` directives, so Tailwind automatically detects all component classes. See [Tailwind CSS Setup](./guides/tailwind-setup) for detailed configuration options and troubleshooting.
+The shipyard packages include built-in `@source` directives, so Tailwind automatically detects all component classes. See [Tailwind CSS Setup](../guides/tailwind-setup) for detailed configuration options and troubleshooting.
 
 ### Astro Configuration
 
@@ -380,7 +380,7 @@ If components appear unstyled or broken:
 
 3. **Check the css config** — Make sure `astro.config.mjs` imports your CSS with `?url` and passes it to shipyard
 
-See [Tailwind CSS Setup](./guides/tailwind-setup) for detailed troubleshooting.
+See [Tailwind CSS Setup](../guides/tailwind-setup) for detailed troubleshooting.
 
 ### Documentation pages return 404
 

--- a/packages/base/src/globals.css
+++ b/packages/base/src/globals.css
@@ -16,7 +16,7 @@
  * @source "../node_modules/@levino/shipyard-docs";
  * @import "@levino/shipyard-base/globals.css";
  *
- * See: https://shipyard.levinkeller.de/docs/guides/tailwind-setup
+ * See: https://shipyard.levinkeller.de/en/docs/guides/tailwind-setup
  */
 
 @import "./styles/components.css";


### PR DESCRIPTION
Fixes #184

## Summary
- Changed relative links from `./guides/tailwind-setup` to `../guides/tailwind-setup` in documentation files
- Fixed absolute URL in `globals.css` to include locale prefix

## Test plan
- [ ] Visit `/en/docs/base-package` and click the Tailwind Setup link
- [ ] Verify the link navigates to `/en/docs/guides/tailwind-setup` (not 404)
- [ ] Check the same for German docs (`/de/docs/base-package`)

Generated with [Claude Code](https://claude.ai/claude-code)