### PR TITLE
fix: add prerender export to fix getStaticPaths warnings in SSR mode

### DIFF
--- a/packages/blog/astro/BlogArchive.astro
+++ b/packages/blog/astro/BlogArchive.astro
@@ -9,6 +9,8 @@ import type { GetStaticPaths } from 'astro'
 import { groupBy, map, pipe, prop, reverse, sortBy, toPairs } from 'ramda'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 const { includeDraftsInDev, routeBasePath } = blogConfig
 
 // Filter out draft and unlisted posts

--- a/packages/blog/astro/BlogAuthorPage.astro
+++ b/packages/blog/astro/BlogAuthorPage.astro
@@ -19,6 +19,8 @@ import {
 import type { Author } from '../src/index'
 import { getReadingTime } from '../src/readingTime'
 
+export const prerender = true
+
 const {
   showReadingTime,
   includeDraftsInDev: includeDraftsInDevConfig,

--- a/packages/blog/astro/BlogAuthorsIndex.astro
+++ b/packages/blog/astro/BlogAuthorsIndex.astro
@@ -20,6 +20,8 @@ import {
 } from 'ramda'
 import type { Author } from '../src/index'
 
+export const prerender = true
+
 export async function getStaticPaths() {
   const { authorsEnabled } = blogConfig
 

--- a/packages/blog/astro/BlogEntry.astro
+++ b/packages/blog/astro/BlogEntry.astro
@@ -12,6 +12,8 @@ import BlogReadingTime from './BlogReadingTime.astro'
 import BlogTags from './BlogTags.astro'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 export const getStaticPaths = async () => {
   const allPosts = await getCollection('blog')
 

--- a/packages/blog/astro/BlogIndex.astro
+++ b/packages/blog/astro/BlogIndex.astro
@@ -8,6 +8,8 @@ import BlogReadingTime from './BlogReadingTime.astro'
 import BlogTags from './BlogTags.astro'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 const {
   postsPerPage,
   showReadingTime,

--- a/packages/blog/astro/BlogIndexPaginated.astro
+++ b/packages/blog/astro/BlogIndexPaginated.astro
@@ -5,6 +5,8 @@ import blogConfig from 'virtual:shipyard-blog/config'
 import type { GetStaticPaths } from 'astro'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 const { postsPerPage, routeBasePath } = blogConfig
 
 export const getStaticPaths = (async () => {

--- a/packages/blog/astro/BlogTagPage.astro
+++ b/packages/blog/astro/BlogTagPage.astro
@@ -22,6 +22,8 @@ import BlogReadingTime from './BlogReadingTime.astro'
 import BlogTags from './BlogTags.astro'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 export const getStaticPaths = (async () => {
   const allPosts = await getCollection('blog')
   const { includeDraftsInDev } = blogConfig

--- a/packages/blog/astro/BlogTagsIndex.astro
+++ b/packages/blog/astro/BlogTagsIndex.astro
@@ -11,6 +11,8 @@ import { groupBy, map, pipe, prop, reverse, sortBy, toPairs } from 'ramda'
 import { getTagDescription, getTagLabel, getTagPermalink } from '../src/index'
 import Layout from './Layout.astro'
 
+export const prerender = true
+
 const { includeDraftsInDev, routeBasePath } = blogConfig
 
 // Filter out draft and unlisted posts

--- a/packages/blog/astro/feeds/atom.xml.ts
+++ b/packages/blog/astro/feeds/atom.xml.ts
@@ -8,6 +8,8 @@ import blogConfig from 'virtual:shipyard-blog/config'
 import type { APIRoute, GetStaticPaths } from 'astro'
 import { filter, pipe, reverse, sortBy, take } from 'ramda'
 
+export const prerender = true
+
 const {
   feedOptions,
   includeDraftsInDev,

--- a/packages/blog/astro/feeds/feed.json.ts
+++ b/packages/blog/astro/feeds/feed.json.ts
@@ -9,6 +9,8 @@ import blogConfig from 'virtual:shipyard-blog/config'
 import type { APIRoute, GetStaticPaths } from 'astro'
 import { filter, map, pipe, reverse, sortBy, take } from 'ramda'
 
+export const prerender = true
+
 const {
   feedOptions,
   includeDraftsInDev,

--- a/packages/blog/astro/feeds/rss.xml.ts
+++ b/packages/blog/astro/feeds/rss.xml.ts
@@ -8,6 +8,8 @@ import blogConfig from 'virtual:shipyard-blog/config'
 import type { APIRoute, GetStaticPaths } from 'astro'
 import { filter, pipe, reverse, sortBy, take } from 'ramda'
 
+export const prerender = true
+
 const {
   feedOptions,
   includeDraftsInDev,


### PR DESCRIPTION
## Summary
- Adds `export const prerender = true` to all blog Astro components that use `getStaticPaths`, fixing warnings when used in SSR/server mode
- Makes `getStaticPaths` conditional in the docs entry file generator — only included when `prerender` is true, avoiding Astro warnings about `getStaticPaths` in non-prerendered pages
- Adds explicit `export const prerender` to the generated docs entry files

## Test plan
- [x] `apps/demos/i18n` builds successfully (368 pages)
- [x] `apps/demos/server-mode` builds successfully (server mode)
- [ ] CI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)