### PR TITLE
docs: document all features and add search

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import shipyard from '@levino/shipyard-base'
 import shipyardDocs from '@levino/shipyard-docs'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
+import pagefind from 'astro-pagefind'
 import shipyardBlog from '../../packages/blog/src/index.ts'
 
 // Import CSS URL - Vite resolves the path
@@ -56,6 +57,10 @@ export default defineConfig({
         about: {
           label: 'About',
           href: '/about',
+        },
+        search: {
+          label: 'Search',
+          href: '/search',
         },
       },
       title: 'shipyard',
@@ -137,5 +142,6 @@ description: Introduction to my project
       },
     }),
     shipyardBlog(),
+    pagefind(),
   ],
 })

--- a/apps/docs/docs/de/guides/announcement-bar.md
+++ b/apps/docs/docs/de/guides/announcement-bar.md
@@ -1,0 +1,61 @@
+---
+title: Announcement Bar
+sidebar:
+  position: 5
+description: Add a dismissible announcement banner to the top of your site
+---
+
+# Announcement Bar
+
+shipyard supports a configurable announcement bar that displays at the top of every page. Users can dismiss it, and the dismissed state is remembered via `localStorage`.
+
+## Configuration
+
+Add the `announcementBar` option to your shipyard config:
+
+```javascript
+shipyard({
+  // ... other options
+  announcementBar: {
+    id: 'new-release',
+    content: 'shipyard v1.0 is out! <a href="https://example.com/blog/v1-release">Read the announcement</a>',
+    backgroundColor: '#4f46e5',
+    textColor: '#ffffff',
+    isCloseable: true,
+  },
+})
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `string` | Required | Unique identifier (used for localStorage persistence) |
+| `content` | `string` | Required | HTML content to display |
+| `backgroundColor` | `string` | — | Custom background color |
+| `textColor` | `string` | — | Custom text color |
+| `isCloseable` | `boolean` | `true` | Whether users can dismiss the bar |
+
+## Behavior
+
+- When a user dismisses the announcement bar, it stays hidden across page loads using `localStorage`.
+- Changing the `id` resets the dismissed state, so users see the new announcement.
+- The announcement bar appears above the navigation bar on all pages.
+- HTML is supported in the `content` field, allowing you to include links.
+
+## Example
+
+```javascript
+shipyard({
+  brand: 'My Site',
+  title: 'My Site',
+  tagline: 'Built with shipyard',
+  navigation: { /* ... */ },
+  announcementBar: {
+    id: 'conference-2026',
+    content: 'Join us at DevConf 2026! <a href="https://example.com">Register now</a>',
+    backgroundColor: '#059669',
+    textColor: '#ffffff',
+  },
+})
+```

--- a/apps/docs/docs/de/guides/blog-authors-tags.md
+++ b/apps/docs/docs/de/guides/blog-authors-tags.md
@@ -1,0 +1,161 @@
+---
+title: Blog Authors & Tags
+sidebar:
+  position: 6
+description: Configure blog authors and tags with dedicated pages and feeds
+---
+
+# Blog Authors & Tags
+
+shipyard's blog package supports authors and tags with auto-generated pages for each.
+
+---
+
+## Authors
+
+### Inline Authors
+
+Define authors directly in blog post frontmatter:
+
+```yaml
+---
+title: My Post
+description: A blog post
+date: 2026-01-15
+authors:
+  - name: Jane Doe
+    title: Lead Developer
+    url: https://janedoe.dev
+    image_url: https://example.com/jane.jpg
+---
+```
+
+### Authors File
+
+For shared author data, create an `authors.yml` file in your blog directory:
+
+```yaml
+# blog/authors.yml
+jane:
+  name: Jane Doe
+  title: Lead Developer
+  url: https://janedoe.dev
+  image_url: https://example.com/jane.jpg
+  email: jane@example.com
+
+john:
+  name: John Smith
+  title: Technical Writer
+  url: https://johnsmith.io
+  image_url: https://example.com/john.jpg
+```
+
+Then reference authors by key in frontmatter:
+
+```yaml
+---
+title: My Post
+description: A blog post
+date: 2026-01-15
+authors: jane
+---
+```
+
+For multiple authors:
+
+```yaml
+---
+authors:
+  - jane
+  - john
+---
+```
+
+### Author Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Author's display name |
+| `title` | `string` | No | Author's role or title |
+| `url` | `string` | No | Author's website URL |
+| `image_url` | `string` | No | Author's avatar image |
+| `email` | `string` | No | Author's email address |
+
+### Author Pages
+
+When authors are configured, shipyard auto-generates:
+
+- `/blog/authors` — Index of all authors
+- `/blog/authors/[author]` — Posts filtered by author
+
+---
+
+## Tags
+
+### Using Tags
+
+Add tags to blog post frontmatter:
+
+```yaml
+---
+title: TypeScript Tips
+description: Useful TypeScript patterns
+date: 2026-01-15
+tags:
+  - typescript
+  - best-practices
+---
+```
+
+### Tags File
+
+For custom tag labels, descriptions, and permalinks, create a `tags.yml` file:
+
+```yaml
+# blog/tags.yml
+typescript:
+  label: TypeScript
+  description: Posts about TypeScript programming
+  permalink: /typescript
+
+best-practices:
+  label: Best Practices
+  description: Recommended patterns and approaches
+```
+
+### Tag Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `label` | `string` | No | Display name (defaults to tag key) |
+| `description` | `string` | No | Tag description shown on tag page |
+| `permalink` | `string` | No | Custom URL path for tag page |
+
+### Tag Pages
+
+shipyard auto-generates:
+
+- `/blog/tags` — Index of all tags with post counts
+- `/blog/tags/[tag]` — Posts filtered by tag
+
+---
+
+## Feeds
+
+Blog feeds are automatically generated and include author and tag metadata:
+
+| Feed | URL |
+|------|-----|
+| RSS 2.0 | `/blog/rss.xml` |
+| Atom | `/blog/atom.xml` |
+| JSON Feed | `/blog/feed.json` |
+
+---
+
+## Archive
+
+The blog archive groups posts by year:
+
+- `/blog/archive` — Chronological listing of all posts grouped by year
+
+The archive is generated automatically and requires no configuration.

--- a/apps/docs/docs/de/guides/index.md
+++ b/apps/docs/docs/de/guides/index.md
@@ -12,3 +12,6 @@ Schritt-für-Schritt-Anleitungen für fortgeschrittene shipyard-Funktionen.
 
 - **[Dokumentations-Versionierung](./versioning)** - Pflegen Sie mehrere Versionen Ihrer Dokumentation für verschiedene Software-Releases
 - **[Migration zu versionierten Docs](./migration-to-versioned)** - Schritt-für-Schritt-Anleitung zur Migration bestehender Dokumentation zu versionierten Docs
+- **[Markdown-Funktionen](./markdown-features)** - Admonitions, Code-Blöcke, Tabs und weitere Markdown-Erweiterungen
+- **[Ankündigungsleiste](./announcement-bar)** - Ausblendbare Ankündigungsbanner auf Ihrer Webseite
+- **[Blog-Autoren & Tags](./blog-authors-tags)** - Autorenprofile, Tags, Feeds und Archivseiten

--- a/apps/docs/docs/de/guides/markdown-features.md
+++ b/apps/docs/docs/de/guides/markdown-features.md
@@ -1,0 +1,284 @@
+---
+title: Markdown Features
+sidebar:
+  position: 4
+description: Learn about admonitions, code blocks, tabs, and other enhanced markdown features in shipyard
+---
+
+# Markdown Features
+
+shipyard enhances standard markdown with features like admonitions, code block enhancements, tabs, and more. These features work automatically in all documentation and blog content — no additional configuration is needed.
+
+---
+
+## Admonitions
+
+Admonitions (also called callouts) highlight important information with colored boxes. shipyard supports five types using the `:::` container directive syntax.
+
+### Syntax
+
+````markdown
+:::note
+This is a note. Use it for general information.
+:::
+
+:::tip
+This is a tip. Use it for helpful advice.
+:::
+
+:::info
+This is info. Use it for supplementary information.
+:::
+
+:::warning
+This is a warning. Use it when users should be careful.
+:::
+
+:::danger
+This is a danger notice. Use it for critical warnings.
+:::
+````
+
+### Custom Titles
+
+Add a custom title in square brackets after the type:
+
+````markdown
+:::note[Did you know?]
+You can customize the title of any admonition.
+:::
+
+:::warning[Security Notice]
+Always validate user input before processing.
+:::
+````
+
+### Available Types
+
+| Type | Color | Default Title | Use Case |
+|------|-------|---------------|----------|
+| `note` | Blue | Note | General information |
+| `tip` | Green | Tip | Helpful advice |
+| `info` | Cyan | Info | Supplementary details |
+| `warning` | Yellow | Warning | Caution or potential issues |
+| `danger` | Red | Danger | Critical warnings |
+
+Admonitions follow DaisyUI's semantic color system, so they automatically adapt to your site's theme.
+
+---
+
+## Code Blocks
+
+shipyard enhances code blocks with titles, line numbers, line highlighting, and magic comments.
+
+### Syntax Highlighting
+
+Standard fenced code blocks include syntax highlighting via Shiki:
+
+````markdown
+```javascript
+function greet(name) {
+  console.log(`Hello, ${name}!`)
+}
+```
+````
+
+### Code Block Titles
+
+Add a `title` attribute to display a filename or description above the code block:
+
+````markdown
+```javascript title="src/utils/greet.js"
+export function greet(name) {
+  console.log(`Hello, ${name}!`)
+}
+```
+````
+
+### Line Numbers
+
+Add `showLineNumbers` to display line numbers:
+
+````markdown
+```javascript showLineNumbers
+function calculateSum(numbers) {
+  let sum = 0
+  for (const num of numbers) {
+    sum += num
+  }
+  return sum
+}
+```
+````
+
+Start from a specific line number:
+
+````markdown
+```javascript showLineNumbers=10
+const config = {
+  theme: 'dark',
+  language: 'en',
+}
+```
+````
+
+### Line Highlighting
+
+Highlight specific lines using curly brace syntax in the code fence:
+
+````markdown
+```javascript {2,4-6}
+function processData(data) {
+  const validated = validate(data)       // highlighted
+  const transformed = transform(validated)
+  return {                               // lines 4-6 highlighted
+    success: true,
+    data: transformed,
+  }
+}
+```
+````
+
+### Magic Comments
+
+Use special comments to highlight lines without the comment appearing in the output:
+
+````markdown
+```javascript
+function handleRequest(req, res) {
+  // highlight-next-line
+  const userId = req.params.id
+
+  // highlight-start
+  const user = await db.findUser(userId)
+  if (!user) {
+    return res.status(404).json({ error: 'Not found' })
+  }
+  // highlight-end
+
+  res.json(user)
+}
+```
+````
+
+Supported comment syntaxes:
+
+| Language | Single line | Block start | Block end |
+|----------|------------|-------------|-----------|
+| JavaScript/TypeScript | `// highlight-next-line` | `// highlight-start` | `// highlight-end` |
+| Python | `# highlight-next-line` | `# highlight-start` | `# highlight-end` |
+| Bash/Shell | `# highlight-next-line` | `# highlight-start` | `# highlight-end` |
+| HTML | `<!-- highlight-next-line -->` | `<!-- highlight-start -->` | `<!-- highlight-end -->` |
+
+### Combined Features
+
+Combine titles, line numbers, and highlighting in a single code block:
+
+````markdown
+```typescript title="src/api/users.ts" showLineNumbers {3,7-9}
+import { db } from './database'
+
+export async function getUser(id: string) {
+  const user = await db.users.findUnique({
+    where: { id },
+  })
+  if (!user) {
+    throw new NotFoundError('User not found')
+  }
+  return user
+}
+```
+````
+
+---
+
+## npm2yarn
+
+Code blocks with the `npm2yarn` meta string automatically show tabs for npm, yarn, and pnpm:
+
+````markdown
+```bash npm2yarn
+npm install @levino/shipyard-base
+```
+````
+
+This renders a tabbed code block where users can switch between package managers.
+
+---
+
+## Tabs
+
+The `Tabs` and `TabItem` components let you group content into switchable tabs. Import them in MDX files:
+
+```mdx
+import { Tabs, TabItem } from '@levino/shipyard-base/components'
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npm install my-package
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add my-package
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add my-package
+    ```
+  </TabItem>
+</Tabs>
+```
+
+Tabs persist the selected tab across all tab groups on the page.
+
+---
+
+## Collapsible Sections
+
+Use the HTML `<details>` element for collapsible/expandable content:
+
+```markdown
+<details>
+<summary>Click to expand</summary>
+
+Hidden content goes here. You can include:
+- Lists
+- Code blocks
+- Any other markdown content
+
+</details>
+```
+
+---
+
+## Tables
+
+Standard markdown tables are supported with responsive horizontal scrolling on mobile:
+
+```markdown
+| Feature     | Status    | Notes                |
+|-------------|-----------|----------------------|
+| Admonitions | Supported | All five types       |
+| Code Blocks | Supported | With enhancements    |
+| Tables      | Supported | Responsive scrolling |
+```
+
+---
+
+## Other Markdown Features
+
+shipyard supports all standard markdown features:
+
+- **Bold** and *italic* text
+- ~~Strikethrough~~ text
+- `Inline code`
+- [Links](https://example.com) (internal and external)
+- Ordered and unordered lists
+- Task lists (`- [x]` and `- [ ]`)
+- Blockquotes
+- Images
+- Horizontal rules
+- Heading anchors (auto-generated)

--- a/apps/docs/docs/de/index.md
+++ b/apps/docs/docs/de/index.md
@@ -99,6 +99,12 @@ Jede Demo zeigt verschiedene shipyard-Fähigkeiten. Der Quellcode für alle Demo
 - **[@levino/shipyard-docs](./docs-package)** – Dokumentations-Plugin mit Sidebar und Paginierung
 - **[@levino/shipyard-blog](./blog-package)** – Blog-Plugin mit Beitragsliste und Navigation
 
+### Anleitungen
+
+- **[Markdown-Funktionen](./guides/markdown-features)** – Admonitions, Code-Blöcke, Tabs und mehr
+- **[Ankündigungsleiste](./guides/announcement-bar)** – Ausblendbare seitenweite Banner
+- **[Blog-Autoren & Tags](./guides/blog-authors-tags)** – Autorenprofile, Tags, Feeds und Archiv
+
 ### Weitere Ressourcen
 
 - **[Server-Modus (SSR)](./server-mode)** – shipyard mit Server-Side Rendering verwenden

--- a/apps/docs/docs/en/guides/announcement-bar.md
+++ b/apps/docs/docs/en/guides/announcement-bar.md
@@ -1,0 +1,61 @@
+---
+title: Announcement Bar
+sidebar:
+  position: 5
+description: Add a dismissible announcement banner to the top of your site
+---
+
+# Announcement Bar
+
+shipyard supports a configurable announcement bar that displays at the top of every page. Users can dismiss it, and the dismissed state is remembered via `localStorage`.
+
+## Configuration
+
+Add the `announcementBar` option to your shipyard config:
+
+```javascript
+shipyard({
+  // ... other options
+  announcementBar: {
+    id: 'new-release',
+    content: 'shipyard v1.0 is out! <a href="https://example.com/blog/v1-release">Read the announcement</a>',
+    backgroundColor: '#4f46e5',
+    textColor: '#ffffff',
+    isCloseable: true,
+  },
+})
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `string` | Required | Unique identifier (used for localStorage persistence) |
+| `content` | `string` | Required | HTML content to display |
+| `backgroundColor` | `string` | — | Custom background color |
+| `textColor` | `string` | — | Custom text color |
+| `isCloseable` | `boolean` | `true` | Whether users can dismiss the bar |
+
+## Behavior
+
+- When a user dismisses the announcement bar, it stays hidden across page loads using `localStorage`.
+- Changing the `id` resets the dismissed state, so users see the new announcement.
+- The announcement bar appears above the navigation bar on all pages.
+- HTML is supported in the `content` field, allowing you to include links.
+
+## Example
+
+```javascript
+shipyard({
+  brand: 'My Site',
+  title: 'My Site',
+  tagline: 'Built with shipyard',
+  navigation: { /* ... */ },
+  announcementBar: {
+    id: 'conference-2026',
+    content: 'Join us at DevConf 2026! <a href="https://example.com">Register now</a>',
+    backgroundColor: '#059669',
+    textColor: '#ffffff',
+  },
+})
+```

--- a/apps/docs/docs/en/guides/blog-authors-tags.md
+++ b/apps/docs/docs/en/guides/blog-authors-tags.md
@@ -1,0 +1,161 @@
+---
+title: Blog Authors & Tags
+sidebar:
+  position: 6
+description: Configure blog authors and tags with dedicated pages and feeds
+---
+
+# Blog Authors & Tags
+
+shipyard's blog package supports authors and tags with auto-generated pages for each.
+
+---
+
+## Authors
+
+### Inline Authors
+
+Define authors directly in blog post frontmatter:
+
+```yaml
+---
+title: My Post
+description: A blog post
+date: 2026-01-15
+authors:
+  - name: Jane Doe
+    title: Lead Developer
+    url: https://janedoe.dev
+    image_url: https://example.com/jane.jpg
+---
+```
+
+### Authors File
+
+For shared author data, create an `authors.yml` file in your blog directory:
+
+```yaml
+# blog/authors.yml
+jane:
+  name: Jane Doe
+  title: Lead Developer
+  url: https://janedoe.dev
+  image_url: https://example.com/jane.jpg
+  email: jane@example.com
+
+john:
+  name: John Smith
+  title: Technical Writer
+  url: https://johnsmith.io
+  image_url: https://example.com/john.jpg
+```
+
+Then reference authors by key in frontmatter:
+
+```yaml
+---
+title: My Post
+description: A blog post
+date: 2026-01-15
+authors: jane
+---
+```
+
+For multiple authors:
+
+```yaml
+---
+authors:
+  - jane
+  - john
+---
+```
+
+### Author Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Author's display name |
+| `title` | `string` | No | Author's role or title |
+| `url` | `string` | No | Author's website URL |
+| `image_url` | `string` | No | Author's avatar image |
+| `email` | `string` | No | Author's email address |
+
+### Author Pages
+
+When authors are configured, shipyard auto-generates:
+
+- `/blog/authors` — Index of all authors
+- `/blog/authors/[author]` — Posts filtered by author
+
+---
+
+## Tags
+
+### Using Tags
+
+Add tags to blog post frontmatter:
+
+```yaml
+---
+title: TypeScript Tips
+description: Useful TypeScript patterns
+date: 2026-01-15
+tags:
+  - typescript
+  - best-practices
+---
+```
+
+### Tags File
+
+For custom tag labels, descriptions, and permalinks, create a `tags.yml` file:
+
+```yaml
+# blog/tags.yml
+typescript:
+  label: TypeScript
+  description: Posts about TypeScript programming
+  permalink: /typescript
+
+best-practices:
+  label: Best Practices
+  description: Recommended patterns and approaches
+```
+
+### Tag Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `label` | `string` | No | Display name (defaults to tag key) |
+| `description` | `string` | No | Tag description shown on tag page |
+| `permalink` | `string` | No | Custom URL path for tag page |
+
+### Tag Pages
+
+shipyard auto-generates:
+
+- `/blog/tags` — Index of all tags with post counts
+- `/blog/tags/[tag]` — Posts filtered by tag
+
+---
+
+## Feeds
+
+Blog feeds are automatically generated and include author and tag metadata:
+
+| Feed | URL |
+|------|-----|
+| RSS 2.0 | `/blog/rss.xml` |
+| Atom | `/blog/atom.xml` |
+| JSON Feed | `/blog/feed.json` |
+
+---
+
+## Archive
+
+The blog archive groups posts by year:
+
+- `/blog/archive` — Chronological listing of all posts grouped by year
+
+The archive is generated automatically and requires no configuration.

--- a/apps/docs/docs/en/guides/index.md
+++ b/apps/docs/docs/en/guides/index.md
@@ -13,3 +13,6 @@ Step-by-step guides for advanced shipyard features.
 - **[Tailwind CSS Setup](./tailwind-setup)** - Configure Tailwind CSS 4 with shipyard, including `@source` directives and troubleshooting
 - **[Documentation Versioning](./versioning)** - Maintain multiple versions of your documentation for different software releases
 - **[Migrating to Versioned Docs](./migration-to-versioned)** - Step-by-step guide for migrating existing documentation to versioned docs
+- **[Markdown Features](./markdown-features)** - Admonitions, code blocks, tabs, and other enhanced markdown features
+- **[Announcement Bar](./announcement-bar)** - Add a dismissible announcement banner to your site
+- **[Blog Authors & Tags](./blog-authors-tags)** - Configure blog authors, tags, feeds, and archive pages

--- a/apps/docs/docs/en/guides/markdown-features.md
+++ b/apps/docs/docs/en/guides/markdown-features.md
@@ -1,0 +1,284 @@
+---
+title: Markdown Features
+sidebar:
+  position: 4
+description: Learn about admonitions, code blocks, tabs, and other enhanced markdown features in shipyard
+---
+
+# Markdown Features
+
+shipyard enhances standard markdown with features like admonitions, code block enhancements, tabs, and more. These features work automatically in all documentation and blog content — no additional configuration is needed.
+
+---
+
+## Admonitions
+
+Admonitions (also called callouts) highlight important information with colored boxes. shipyard supports five types using the `:::` container directive syntax.
+
+### Syntax
+
+````markdown
+:::note
+This is a note. Use it for general information.
+:::
+
+:::tip
+This is a tip. Use it for helpful advice.
+:::
+
+:::info
+This is info. Use it for supplementary information.
+:::
+
+:::warning
+This is a warning. Use it when users should be careful.
+:::
+
+:::danger
+This is a danger notice. Use it for critical warnings.
+:::
+````
+
+### Custom Titles
+
+Add a custom title in square brackets after the type:
+
+````markdown
+:::note[Did you know?]
+You can customize the title of any admonition.
+:::
+
+:::warning[Security Notice]
+Always validate user input before processing.
+:::
+````
+
+### Available Types
+
+| Type | Color | Default Title | Use Case |
+|------|-------|---------------|----------|
+| `note` | Blue | Note | General information |
+| `tip` | Green | Tip | Helpful advice |
+| `info` | Cyan | Info | Supplementary details |
+| `warning` | Yellow | Warning | Caution or potential issues |
+| `danger` | Red | Danger | Critical warnings |
+
+Admonitions follow DaisyUI's semantic color system, so they automatically adapt to your site's theme.
+
+---
+
+## Code Blocks
+
+shipyard enhances code blocks with titles, line numbers, line highlighting, and magic comments.
+
+### Syntax Highlighting
+
+Standard fenced code blocks include syntax highlighting via Shiki:
+
+````markdown
+```javascript
+function greet(name) {
+  console.log(`Hello, ${name}!`)
+}
+```
+````
+
+### Code Block Titles
+
+Add a `title` attribute to display a filename or description above the code block:
+
+````markdown
+```javascript title="src/utils/greet.js"
+export function greet(name) {
+  console.log(`Hello, ${name}!`)
+}
+```
+````
+
+### Line Numbers
+
+Add `showLineNumbers` to display line numbers:
+
+````markdown
+```javascript showLineNumbers
+function calculateSum(numbers) {
+  let sum = 0
+  for (const num of numbers) {
+    sum += num
+  }
+  return sum
+}
+```
+````
+
+Start from a specific line number:
+
+````markdown
+```javascript showLineNumbers=10
+const config = {
+  theme: 'dark',
+  language: 'en',
+}
+```
+````
+
+### Line Highlighting
+
+Highlight specific lines using curly brace syntax in the code fence:
+
+````markdown
+```javascript {2,4-6}
+function processData(data) {
+  const validated = validate(data)       // highlighted
+  const transformed = transform(validated)
+  return {                               // lines 4-6 highlighted
+    success: true,
+    data: transformed,
+  }
+}
+```
+````
+
+### Magic Comments
+
+Use special comments to highlight lines without the comment appearing in the output:
+
+````markdown
+```javascript
+function handleRequest(req, res) {
+  // highlight-next-line
+  const userId = req.params.id
+
+  // highlight-start
+  const user = await db.findUser(userId)
+  if (!user) {
+    return res.status(404).json({ error: 'Not found' })
+  }
+  // highlight-end
+
+  res.json(user)
+}
+```
+````
+
+Supported comment syntaxes:
+
+| Language | Single line | Block start | Block end |
+|----------|------------|-------------|-----------|
+| JavaScript/TypeScript | `// highlight-next-line` | `// highlight-start` | `// highlight-end` |
+| Python | `# highlight-next-line` | `# highlight-start` | `# highlight-end` |
+| Bash/Shell | `# highlight-next-line` | `# highlight-start` | `# highlight-end` |
+| HTML | `<!-- highlight-next-line -->` | `<!-- highlight-start -->` | `<!-- highlight-end -->` |
+
+### Combined Features
+
+Combine titles, line numbers, and highlighting in a single code block:
+
+````markdown
+```typescript title="src/api/users.ts" showLineNumbers {3,7-9}
+import { db } from './database'
+
+export async function getUser(id: string) {
+  const user = await db.users.findUnique({
+    where: { id },
+  })
+  if (!user) {
+    throw new NotFoundError('User not found')
+  }
+  return user
+}
+```
+````
+
+---
+
+## npm2yarn
+
+Code blocks with the `npm2yarn` meta string automatically show tabs for npm, yarn, and pnpm:
+
+````markdown
+```bash npm2yarn
+npm install @levino/shipyard-base
+```
+````
+
+This renders a tabbed code block where users can switch between package managers.
+
+---
+
+## Tabs
+
+The `Tabs` and `TabItem` components let you group content into switchable tabs. Import them in MDX files:
+
+```mdx
+import { Tabs, TabItem } from '@levino/shipyard-base/components'
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npm install my-package
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add my-package
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add my-package
+    ```
+  </TabItem>
+</Tabs>
+```
+
+Tabs persist the selected tab across all tab groups on the page.
+
+---
+
+## Collapsible Sections
+
+Use the HTML `<details>` element for collapsible/expandable content:
+
+```markdown
+<details>
+<summary>Click to expand</summary>
+
+Hidden content goes here. You can include:
+- Lists
+- Code blocks
+- Any other markdown content
+
+</details>
+```
+
+---
+
+## Tables
+
+Standard markdown tables are supported with responsive horizontal scrolling on mobile:
+
+```markdown
+| Feature     | Status    | Notes                |
+|-------------|-----------|----------------------|
+| Admonitions | Supported | All five types       |
+| Code Blocks | Supported | With enhancements    |
+| Tables      | Supported | Responsive scrolling |
+```
+
+---
+
+## Other Markdown Features
+
+shipyard supports all standard markdown features:
+
+- **Bold** and *italic* text
+- ~~Strikethrough~~ text
+- `Inline code`
+- [Links](https://example.com) (internal and external)
+- Ordered and unordered lists
+- Task lists (`- [x]` and `- [ ]`)
+- Blockquotes
+- Images
+- Horizontal rules
+- Heading anchors (auto-generated)

--- a/apps/docs/docs/en/index.md
+++ b/apps/docs/docs/en/index.md
@@ -99,6 +99,12 @@ Each demo showcases different shipyard capabilities. The source code for all dem
 - **[@levino/shipyard-docs](./docs-package)** – Documentation plugin with sidebar and pagination
 - **[@levino/shipyard-blog](./blog-package)** – Blog plugin with post listing and navigation
 
+### Guides
+
+- **[Markdown Features](./guides/markdown-features)** – Admonitions, code blocks, tabs, and more
+- **[Announcement Bar](./guides/announcement-bar)** – Dismissible site-wide banners
+- **[Blog Authors & Tags](./guides/blog-authors-tags)** – Author profiles, tags, feeds, and archive
+
 ### Additional Resources
 
 - **[Server Mode (SSR)](./server-mode)** – Using shipyard with server-side rendering

--- a/apps/docs/docs/en/roadmap.md
+++ b/apps/docs/docs/en/roadmap.md
@@ -24,7 +24,7 @@ This document tracks shipyard's progress towards supporting features from Docusa
 - [x] Generate documentation routes automatically
 - [x] Documentation sidebar navigation
 - [x] Multiple documentation instances (multi-instance docs)
-- [ ] Documentation versioning
+- [x] Documentation versioning
 
 ### Configuration Options
 
@@ -106,13 +106,13 @@ This document tracks shipyard's progress towards supporting features from Docusa
 
 ### Versioning
 
-- [ ] Create versioned documentation snapshots
-- [ ] Version dropdown selector
-- [ ] Version badges
-- [ ] Unmaintained version banners
-- [ ] Custom version labels
-- [ ] Version-specific sidebars
-- [ ] Version-specific edit URLs
+- [x] Create versioned documentation snapshots
+- [x] Version dropdown selector
+- [x] Version badges
+- [x] Unmaintained version banners
+- [x] Custom version labels
+- [x] Version-specific sidebars
+- [x] Version-specific edit URLs
 
 ### SEO Features
 
@@ -301,7 +301,7 @@ This document tracks shipyard's progress towards supporting features from Docusa
 - [x] Sidebar navigation (docs)
 - [x] Breadcrumbs
 - [x] Table of contents
-- [ ] Search integration
+- [x] Search integration
 - [x] Announcement banner
 - [x] Theme/dark mode toggle
 
@@ -346,7 +346,7 @@ The following Docusaurus features are **not applicable** because Astro handles t
 
 ### Medium Priority (Enhanced Features)
 
-1. **Search integration** - Critical for larger docs
+1. ~~**Search integration**~~ - ✅ Implemented (via Pagefind)
 2. ~~**"Edit this page" links**~~ - ✅ Implemented
 3. ~~**Last updated timestamps**~~ - ✅ Implemented
 4. ~~**Code block enhancements**~~ - ✅ Implemented (line numbers, highlighting, titles)
@@ -356,7 +356,7 @@ The following Docusaurus features are **not applicable** because Astro handles t
 
 ### Lower Priority (Advanced Features)
 
-1. **Documentation versioning** - Complex feature for mature projects
+1. ~~**Documentation versioning**~~ - ✅ Implemented (multi-version docs with version selector)
 2. ~~**Multi-instance docs/blogs**~~ - ✅ Implemented (routeBasePath for both docs and blogs)
 3. ~~**Sidebar link type**~~ - ✅ Implemented (external/internal links in sidebar)
 4. ~~**Author pages**~~ - ✅ Implemented (generated author pages for blog)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,7 @@
     "@levino/shipyard-docs": "*",
     "@tailwindcss/vite": "^4",
     "astro": "^5.15",
+    "astro-pagefind": "^1.8.5",
     "daisyui": "^5",
     "tailwindcss": "^4"
   },

--- a/apps/docs/src/pages/en/search.astro
+++ b/apps/docs/src/pages/en/search.astro
@@ -1,0 +1,11 @@
+---
+import { Page } from '@levino/shipyard-base/layouts'
+import Search from 'astro-pagefind/components/Search'
+---
+
+<Page title="Search" description="Search the shipyard documentation">
+  <div class="prose max-w-none py-8">
+    <h1>Search</h1>
+    <Search id="search" className="pagefind-ui" uiOptions={{ showImages: false, showSubResults: true }} />
+  </div>
+</Page>

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,7 @@
         "@levino/shipyard-docs": "*",
         "@tailwindcss/vite": "^4",
         "astro": "^5.15",
+        "astro-pagefind": "^1.8.5",
         "daisyui": "^5",
         "tailwindcss": "^4"
       },
@@ -8808,6 +8809,90 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.4.0.tgz",
+      "integrity": "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@playwright/test": {
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
@@ -11180,6 +11265,34 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro-pagefind": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-1.8.5.tgz",
+      "integrity": "sha512-CVhKKA9bTQ7hLsHk9KTNDzOdgR4EI04gn0mjDGfnXzaHx7rL92YkNpFM5AoFl9NWmOUbaIFC2DN7Yvs/ZFPRdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/default-ui": "^1.2.0",
+        "pagefind": "^1.2.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/astro-pagefind/node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/astro/node_modules/boxen": {
@@ -21780,6 +21893,23 @@
         "quansync": "^0.2.7"
       }
     },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -28570,6 +28700,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28586,6 +28717,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28602,6 +28734,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28618,6 +28751,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28634,6 +28768,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28650,6 +28785,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28666,6 +28802,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28682,6 +28819,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28698,6 +28836,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28714,6 +28853,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28730,6 +28870,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28746,6 +28887,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28762,6 +28904,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28778,6 +28921,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28794,6 +28938,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28810,6 +28955,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28826,6 +28972,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28842,6 +28989,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28858,6 +29006,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28874,6 +29023,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28890,6 +29040,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28906,6 +29057,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28922,6 +29074,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28938,6 +29091,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28954,6 +29108,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -28970,6 +29125,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -30537,7 +30693,7 @@
     },
     "packages/base": {
       "name": "@levino/shipyard-base",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.0",
@@ -31182,10 +31338,10 @@
     },
     "packages/blog": {
       "name": "@levino/shipyard-blog",
-      "version": "0.6.2",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@levino/shipyard-base": "^0.7.0",
+        "@levino/shipyard-base": "^0.7.1",
         "ramda": "^0.31",
         "yaml": "^2.0.0"
       },
@@ -31199,10 +31355,10 @@
     },
     "packages/docs": {
       "name": "@levino/shipyard-docs",
-      "version": "0.6.4",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@levino/shipyard-base": "^0.7.0",
+        "@levino/shipyard-base": "^0.7.1",
         "effect": "^3.12.5",
         "ramda": "^0.31",
         "unist-util-visit": "^5.0.0"


### PR DESCRIPTION
Closes #194

## Summary
- Add Markdown Features guide (admonitions, code blocks, tabs)
- Add Announcement Bar guide
- Add Blog Authors & Tags guide
- Add full-text search with PageFind
- Update docs landing page and guides index (EN + DE)
- Update roadmap to mark search and versioning as implemented

## Test plan
- [ ] Verify search page works at /en/search
- [ ] Verify new guide pages render correctly
- [ ] Verify navigation links work
- [ ] Build passes with link checker

Generated with [Claude Code](https://claude.ai/claude-code)