### PR TITLE
Update Claude workflow permissions settings

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,24 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --dangerously-skip-permissions --model claude-opus-4-6
-          # This is an optional setting that allows Claude to read CI results on PRs
+          claude_args: --model claude-opus-4-6
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash",
+                  "Read",
+                  "Edit",
+                  "Write",
+                  "Glob",
+                  "Grep",
+                  "WebFetch",
+                  "WebSearch",
+                  "TodoWrite",
+                  "Task",
+                  "NotebookEdit"
+                ]
+              }
+            }
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Removed 'dangerously-skip-permissions' from claude_args and added permissions settings.