### PR TITLE
Add changeset for Astro 6 upgrade (breaking change)

### DIFF
--- a/.changeset/astro-6-upgrade.md
+++ b/.changeset/astro-6-upgrade.md
@@ -1,0 +1,7 @@
+---
+'@levino/shipyard-base': minor
+'@levino/shipyard-blog': minor
+'@levino/shipyard-docs': minor
+---
+
+Upgrade to Astro 6. All shipyard packages now require Astro 6 (`^6.0.0`) and no longer support Astro 5. This includes updated compatibility with Zod 4, @astrojs/mdx 5, @astrojs/cloudflare 13, and @astrojs/node 10.


### PR DESCRIPTION
The Astro 5 → 6 upgrade is a breaking change for all three shipyard
packages, requiring a minor version bump under 0.x.y semver.

https://claude.ai/code/session_01717ZatA9WvZ2Jpgu7XUjPb