### PR TITLE
docs: make setup docs self-contained for LLM readers

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -87,26 +87,88 @@ export default defineConfig({
           'shipyard is an Astro-based page builder for creating documentation sites, blogs, and content-focused websites with responsive design, i18n support, and modular components.',
         description: `shipyard provides three packages: @levino/shipyard-base (core layouts and configuration), @levino/shipyard-docs (documentation features with sidebar and pagination), and @levino/shipyard-blog (blog functionality). It uses Tailwind CSS 4 with DaisyUI 5 for styling.
 
-## Quick Start
+## Complete Setup (all steps required)
 
-Install packages:
+### Step 1: Install packages
+
+Full-featured site (docs + blog):
 \`\`\`bash
-npm install @levino/shipyard-base @levino/shipyard-docs tailwindcss daisyui @tailwindcss/typography @tailwindcss/vite
+npm install @levino/shipyard-base @levino/shipyard-docs @levino/shipyard-blog tailwindcss @tailwindcss/vite daisyui @tailwindcss/typography
 \`\`\`
 
-Configure astro.config.mjs:
+Documentation site only (no blog):
+\`\`\`bash
+npm install @levino/shipyard-base @levino/shipyard-docs tailwindcss @tailwindcss/vite daisyui @tailwindcss/typography
+\`\`\`
+
+### Step 2: Create src/styles/app.css
+
+This file is required. Every \`@import\` shown below is needed — each shipyard package ships its own \`@source\` directives that tell Tailwind where to scan for classes. Missing an import causes partially unstyled components.
+
+Full-featured site (docs + blog):
+\`\`\`css
+@import "tailwindcss";
+@import "@levino/shipyard-base";
+@import "@levino/shipyard-blog";
+@import "@levino/shipyard-docs";
+@plugin "daisyui";
+@plugin "@tailwindcss/typography";
+\`\`\`
+
+Documentation site only (no blog — omit the blog import):
+\`\`\`css
+@import "tailwindcss";
+@import "@levino/shipyard-base";
+@import "@levino/shipyard-docs";
+@plugin "daisyui";
+@plugin "@tailwindcss/typography";
+\`\`\`
+
+### Step 3: Configure astro.config.mjs
+
+The \`?url\` import and \`css: appCss\` parameter are both required — without them, styles will not be applied.
+
+Full-featured site:
+\`\`\`javascript
+import shipyard from '@levino/shipyard-base'
+import shipyardDocs from '@levino/shipyard-docs'
+import shipyardBlog from '@levino/shipyard-blog'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'astro/config'
+import appCss from './src/styles/app.css?url'
+
+export default defineConfig({
+  vite: { plugins: [tailwindcss()] },
+  integrations: [
+    shipyard({
+      css: appCss,
+      brand: 'My Site',
+      title: 'My Site',
+      tagline: 'Built with shipyard',
+      navigation: {
+        docs: { label: 'Docs', href: '/docs' },
+        blog: { label: 'Blog', href: '/blog' },
+      },
+    }),
+    shipyardDocs(),
+    shipyardBlog(),
+  ],
+})
+\`\`\`
+
+Documentation site only:
 \`\`\`javascript
 import shipyard from '@levino/shipyard-base'
 import shipyardDocs from '@levino/shipyard-docs'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
+import appCss from './src/styles/app.css?url'
 
 export default defineConfig({
-  vite: {
-    plugins: [tailwindcss()],
-  },
+  vite: { plugins: [tailwindcss()] },
   integrations: [
     shipyard({
+      css: appCss,
       brand: 'My Site',
       title: 'My Site',
       tagline: 'Built with shipyard',
@@ -119,7 +181,26 @@ export default defineConfig({
 })
 \`\`\`
 
-Configure src/content.config.ts (Astro 5+):
+### Step 4: Configure src/content.config.ts (Astro 5+)
+
+This file is essential. Without it you get "The collection does not exist" errors.
+
+Full-featured site:
+\`\`\`typescript
+import { defineCollection } from 'astro:content'
+import { createDocsCollection } from '@levino/shipyard-docs'
+import { blogSchema } from '@levino/shipyard-blog'
+import { glob } from 'astro/loaders'
+
+const docs = defineCollection(createDocsCollection('./docs'))
+const blog = defineCollection({
+  schema: blogSchema,
+  loader: glob({ pattern: '**/*.md', base: './blog' }),
+})
+export const collections = { docs, blog }
+\`\`\`
+
+Documentation site only:
 \`\`\`typescript
 import { defineCollection } from 'astro:content'
 import { createDocsCollection } from '@levino/shipyard-docs'
@@ -128,7 +209,9 @@ const docs = defineCollection(createDocsCollection('./docs'))
 export const collections = { docs }
 \`\`\`
 
-Example docs frontmatter (docs/index.md):
+### Step 5: Create content
+
+Create docs/index.md:
 \`\`\`yaml
 ---
 title: Getting Started
@@ -138,11 +221,20 @@ description: Introduction to my project
 ---
 \`\`\`
 
+## Common Mistakes
+
+- **Missing \`css: appCss\` or \`?url\` import**: Components render but are completely unstyled.
+- **Missing a shipyard CSS import**: Components from the missing package are partially unstyled because Tailwind doesn't scan that package's classes.
+- **Missing \`src/content.config.ts\`**: Build fails with "The collection does not exist".
+
 ## Key Documentation Pages
 
-- [Getting Started](/en/docs/getting-started) - Full setup guide
+- [Getting Started](/en/docs/getting-started) - Full setup guide with troubleshooting
+- [Tailwind CSS Setup](/en/docs/guides/tailwind-setup) - Detailed CSS configuration and migration guide
 - [Base Package](/en/docs/base-package) - Layouts, navigation, and configuration
-- [Docs Package](/en/docs/docs-package) - Sidebar, pagination, and frontmatter options`,
+- [Docs Package](/en/docs/docs-package) - Sidebar, pagination, and frontmatter options
+- [Blog Package](/en/docs/blog-package) - Blog functionality and customization
+- [Server Mode](/en/docs/server-mode) - Server-side rendering with auth middleware`,
       },
     }),
     shipyardBlog(),

--- a/apps/docs/docs/en/getting-started.md
+++ b/apps/docs/docs/en/getting-started.md
@@ -37,6 +37,8 @@ npm install @levino/shipyard-base @levino/shipyard-blog
 npm install @levino/shipyard-base
 ```
 
+> **Tip:** The commands above install the latest version. For reproducible builds, pin versions in your `package.json` (e.g. `"@levino/shipyard-base": "^0.8.0"`). Check [npm](https://www.npmjs.com/package/@levino/shipyard-base) for the latest release.
+
 ### Step 2: Install Peer Dependencies
 
 shipyard requires the following peer dependencies:
@@ -65,6 +67,8 @@ The most commonly missed file is `src/content.config.ts` — without it, you'll 
 
 Create `src/styles/app.css` with the Tailwind CSS 4 configuration:
 
+**Full-featured site (docs + blog):**
+
 ```css
 /* Tailwind CSS 4 setup */
 @import "tailwindcss";
@@ -78,7 +82,21 @@ Create `src/styles/app.css` with the Tailwind CSS 4 configuration:
 @plugin "@tailwindcss/typography";
 ```
 
-The shipyard packages include built-in `@source` directives, so Tailwind automatically detects all component classes. See [Tailwind CSS Setup](../guides/tailwind-setup) for detailed configuration options and troubleshooting.
+**Documentation site only (no blog):**
+
+```css
+@import "tailwindcss";
+
+@import "@levino/shipyard-base";
+@import "@levino/shipyard-docs";
+
+@plugin "daisyui";
+@plugin "@tailwindcss/typography";
+```
+
+**Important:** Only import the shipyard packages you installed. Each package ships `@source` directives that tell Tailwind where to scan for CSS classes. If you omit a package you use, its components will be partially unstyled because Tailwind won't generate the needed utility classes. If you include a package you didn't install, the build will fail.
+
+See [Tailwind CSS Setup](../guides/tailwind-setup) for detailed configuration options and troubleshooting.
 
 ### Astro Configuration
 

--- a/apps/docs/docs/en/guides/tailwind-setup.md
+++ b/apps/docs/docs/en/guides/tailwind-setup.md
@@ -65,6 +65,22 @@ npm install tailwindcss @tailwindcss/vite daisyui @tailwindcss/typography
 
 That's it! The shipyard packages include their own `@source` directives, so Tailwind automatically detects all component classes.
 
+### Docs-only Setup (no blog)
+
+If you're not using `@levino/shipyard-blog`, omit its CSS import:
+
+```css
+@import "tailwindcss";
+
+@import "@levino/shipyard-base";
+@import "@levino/shipyard-docs";
+
+@plugin "daisyui";
+@plugin "@tailwindcss/typography";
+```
+
+Only import the packages you installed. Each `@import` registers `@source` directives for that package — importing a package you didn't install will cause build errors, while omitting an installed package will result in partially unstyled components.
+
 ## How It Works
 
 Each shipyard package exports CSS via conditional exports. When imported in CSS with `@import`, it resolves to a CSS file that contains:

--- a/apps/docs/docs/en/server-mode.md
+++ b/apps/docs/docs/en/server-mode.md
@@ -122,6 +122,89 @@ const data = await fetch('https://api.example.com/data')
 ---
 ```
 
+## Server Mode with Auth Middleware (Express)
+
+A common pattern is to wrap Astro's Node.js server behind an Express app that handles authentication (e.g. Passport.js, session stores). Here's how to set that up with shipyard.
+
+### Configuration
+
+When docs sit behind authentication middleware, pages must be rendered on every request so the middleware can check credentials. Set `prerender: false` explicitly:
+
+```javascript
+import node from '@astrojs/node'
+import shipyard from '@levino/shipyard-base'
+import shipyardDocs from '@levino/shipyard-docs'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'astro/config'
+import appCss from './src/styles/app.css?url'
+
+export default defineConfig({
+  output: 'server',
+  adapter: node({ mode: 'middleware' }),
+  vite: {
+    plugins: [tailwindcss()],
+  },
+  integrations: [
+    shipyard({
+      css: appCss,
+      brand: 'Internal Docs',
+      title: 'Internal Docs',
+      navigation: {
+        docs: { label: 'Docs', href: '/docs' },
+      },
+    }),
+    shipyardDocs({ prerender: false }),
+  ],
+})
+```
+
+### Express Wrapper
+
+Use Astro's Node.js adapter in `middleware` mode and mount it inside Express:
+
+```javascript
+// server.mjs
+import express from 'express'
+import { handler as astroHandler } from './dist/server/entry.mjs'
+
+const app = express()
+
+// Your auth middleware (e.g. Passport, session)
+app.use(session({ /* ... */ }))
+app.use(passport.initialize())
+app.use(passport.session())
+app.use((req, res, next) => {
+  if (req.isAuthenticated()) return next()
+  res.redirect('/login')
+})
+
+// Mount Astro as the final handler
+app.use(astroHandler)
+
+app.listen(3000)
+```
+
+### Root Path Redirect
+
+When your docs are the only content, redirect the root path to `/docs`:
+
+```astro
+---
+// src/pages/index.astro
+return Astro.redirect('/docs', 302)
+---
+```
+
+This avoids needing a `routeBasePath` workaround and keeps the URL structure clean.
+
+### Key Points
+
+| Setting | Why |
+|---------|-----|
+| `output: 'server'` | Enables SSR so middleware runs on every request |
+| `adapter: node({ mode: 'middleware' })` | Lets you mount Astro inside Express |
+| `shipyardDocs({ prerender: false })` | Prevents docs from being pre-rendered at build time, which would bypass auth |
+
 ## Live Demo
 
 See server mode in action: **[Server Mode Demo](https://server-mode.demos.shipyard.levinkeller.de)**


### PR DESCRIPTION
## Summary

- Rewrote llms.txt Quick Start with complete setup steps (app.css, astro.config.mjs with `?url` import + `css: appCss`, content.config.ts)
- Added docs-only (no blog) CSS examples across all setup pages
- Added Server Mode + Auth Middleware (Express) recipe
- Added version pinning tip and Common Mistakes section

Closes #217

Generated with [Claude Code](https://claude.ai/code)