### PR TITLE
fix(base): keep German gender colons (`:innen`) as plain text

### DIFF
--- a/.changeset/german-gender-colon-fix.md
+++ b/.changeset/german-gender-colon-fix.md
@@ -1,0 +1,5 @@
+---
+'@levino/shipyard-base': patch
+---
+
+You can now use the German gender colon (e.g. `Organisator:innen`, `Ordner:innen`, `Anwohner:innen`) in your markdown without it tearing paragraphs apart. Previously the `:innen` suffix was parsed as an inline directive and rendered as an empty `<div>`, which broke the surrounding paragraph. Inline `:name` directives are no longer recognised — block directives like `:::note` admonitions still work as before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27967,6 +27967,7 @@
       "dependencies": {
         "clsx": "^2.1.0",
         "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^3.0.0",
         "ramda": "^0.31",
         "remark-directive": "^3.0.0",
         "tailwind-merge": "^2.2.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "clsx": "^2.1.0",
     "mdast-util-directive": "^3.0.0",
+    "micromark-extension-directive": "^3.0.0",
     "ramda": "^0.31",
     "remark-directive": "^3.0.0",
     "tailwind-merge": "^2.2.0",

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import type { AstroIntegration } from 'astro'
-import remarkDirective from 'remark-directive'
 import { remarkAdmonitions } from './remark/remarkAdmonitions'
+import { remarkBlockDirective } from './remark/remarkBlockDirective'
 import { remarkNpm2Yarn } from './remark/remarkNpm2Yarn'
 import type { Config } from './schemas/config'
 import { checkLinks, reportBrokenLinks } from './tools/linkChecker'
@@ -47,7 +47,11 @@ export default (config: Config): AstroIntegration => {
 
         updateConfig({
           markdown: {
-            remarkPlugins: [remarkDirective, remarkAdmonitions, remarkNpm2Yarn],
+            remarkPlugins: [
+              remarkBlockDirective,
+              remarkAdmonitions,
+              remarkNpm2Yarn,
+            ],
           },
           vite: {
             plugins: [

--- a/packages/base/src/remark/index.ts
+++ b/packages/base/src/remark/index.ts
@@ -9,4 +9,5 @@
 // Re-export remark-directive for convenience
 export { default as remarkDirective } from 'remark-directive'
 export { type AdmonitionType, remarkAdmonitions } from './remarkAdmonitions'
+export { remarkBlockDirective } from './remarkBlockDirective'
 export { remarkNpm2Yarn } from './remarkNpm2Yarn'

--- a/packages/base/src/remark/remarkBlockDirective.test.ts
+++ b/packages/base/src/remark/remarkBlockDirective.test.ts
@@ -1,0 +1,69 @@
+import { remark } from 'remark'
+import remarkHtml from 'remark-html'
+import { describe, expect, it } from 'vitest'
+import { remarkAdmonitions } from './remarkAdmonitions'
+import { remarkBlockDirective } from './remarkBlockDirective'
+
+const process = async (markdown: string): Promise<string> => {
+  const result = await remark()
+    .use(remarkBlockDirective)
+    .use(remarkAdmonitions)
+    .use(remarkHtml, { sanitize: false })
+    .process(markdown)
+  return String(result)
+}
+
+describe('remarkBlockDirective', () => {
+  describe('German gender colon', () => {
+    it('does not split paragraphs containing :innen', async () => {
+      const input =
+        'herzlicher Dank an die Organisator:innen vom **ADFC** und an alle Ordner:innen'
+      const result = await process(input)
+      expect(result).toContain('Organisator:innen')
+      expect(result).toContain('Ordner:innen')
+      expect(result).not.toContain('<div></div>')
+    })
+
+    it('preserves :innen inside a paragraph as plain text', async () => {
+      const input = 'Liebe Anwohner:innen, willkommen.'
+      const result = await process(input)
+      expect(result).toContain('Liebe Anwohner:innen, willkommen.')
+    })
+
+    it('handles multiple gender colon variants in one paragraph', async () => {
+      const input = 'Mitarbeiter:innen, Lehrer:innen und Schüler:innen.'
+      const result = await process(input)
+      expect(result).toContain(
+        'Mitarbeiter:innen, Lehrer:innen und Schüler:innen.',
+      )
+      expect(result).not.toContain('<div></div>')
+    })
+  })
+
+  describe('container directives', () => {
+    it('still parses :::note admonitions', async () => {
+      const input = ':::note\nThis is a note\n:::'
+      const result = await process(input)
+      expect(result).toContain('admonition')
+      expect(result).toContain('admonition-note')
+      expect(result).toContain('This is a note')
+    })
+
+    it('still parses :::warning with custom title', async () => {
+      const input = ':::warning[Be Careful]\nWatch out\n:::'
+      const result = await process(input)
+      expect(result).toContain('admonition-warning')
+      expect(result).toContain('Be Careful')
+    })
+  })
+
+  describe('inline text directives', () => {
+    it('does not consume :name as a directive', async () => {
+      const input = 'Use :foo as a marker.'
+      const result = await process(input)
+      // Without text-directive support `:foo` stays as plain text.
+      expect(result).toContain(':foo')
+      expect(result).not.toContain('<div></div>')
+    })
+  })
+})

--- a/packages/base/src/remark/remarkBlockDirective.ts
+++ b/packages/base/src/remark/remarkBlockDirective.ts
@@ -1,0 +1,35 @@
+import type { Root } from 'mdast'
+import { directiveFromMarkdown } from 'mdast-util-directive'
+import { directive } from 'micromark-extension-directive'
+import type { Plugin, Processor } from 'unified'
+
+/**
+ * Like `remark-directive`, but only enables block-level directives — container
+ * (`:::name`) and leaf (`::name`) — and disables inline text directives
+ * (`:name`).
+ *
+ * Why: the inline text directive syntax conflicts with the German gender
+ * colon (e.g. `Organisator:innen`, `Ordner:innen`), which would otherwise be
+ * tokenised as a directive and rendered as an empty `<div>`, tearing the
+ * surrounding paragraph apart.
+ *
+ * Block directives stay available so admonitions (`:::note`, `:::warning`)
+ * keep working.
+ */
+export const remarkBlockDirective: Plugin<[], Root> = function () {
+  const self = this as unknown as Processor<Root>
+  const data = self.data()
+
+  if (!data.micromarkExtensions) {
+    data.micromarkExtensions = []
+  }
+  if (!data.fromMarkdownExtensions) {
+    data.fromMarkdownExtensions = []
+  }
+
+  const { flow } = directive()
+  data.micromarkExtensions.push({ flow })
+  data.fromMarkdownExtensions.push(directiveFromMarkdown())
+}
+
+export default remarkBlockDirective


### PR DESCRIPTION
Closes #221

## Summary

`remark-directive`'s default `directive()` micromark extension registers both block directives (`:::name`) and inline text directives (`:name`). The inline variant collides with the German gender colon (`Organisator:innen`, `Ordner:innen`, `Anwohner:innen`), causing the suffix to be parsed as a directive and rendered as an empty `<div></div>`, which tears the surrounding paragraph apart.

This PR introduces `remarkBlockDirective`, a small variant that only registers the `flow` (block) half of the directive syntax. Container directives like `:::note` and `:::warning[Be Careful]` still work; inline `:name` sequences are left alone.

## Test plan

- [x] New unit tests cover the exact paragraph from the issue and several `:innen` variants
- [x] New unit tests confirm `:::note` and `:::warning[...]` admonitions still render
- [x] `npm run test:unit` — all 50 tests pass
- [x] `npx @biomejs/biome@2.2.3 check` — no new errors

Generated with [Claude Code](https://claude.ai/code)