### PR TITLE
fix(blog): cap featured image height and request optimized variants

### DIFF
--- a/.changeset/blog-index-image-sizing.md
+++ b/.changeset/blog-index-image-sizing.md
@@ -1,0 +1,7 @@
+---
+'@levino/shipyard-base': patch
+'@levino/shipyard-blog': patch
+'@levino/shipyard-docs': patch
+---
+
+Blog index images now stay a sensible size and load faster. The featured first post is rendered as a banner capped at 320 px tall (with `object-cover`) so tall or large source photos no longer dominate the page. Both the featured banner and the side-card thumbnails now request explicit widths from Astro's image pipeline, so the served files are properly downscaled instead of being delivered at the original resolution.

--- a/packages/blog/astro/BlogIndex.astro
+++ b/packages/blog/astro/BlogIndex.astro
@@ -142,11 +142,12 @@ const tagBaseUrl = i18n
           return isFirst && hasImage ? (
             /* Featured first post — full-width card with image */
             <article class="card bg-base-100 shadow-sm relative" data-testid="blog-post-item">
-              <figure>
+              <figure class="max-h-80">
                 <Image
                   src={entry.data.image}
                   alt={entry.data.title}
-                  class="w-full object-cover"
+                  width={1600}
+                  class="w-full h-80 object-cover"
                   loading="eager"
                 />
               </figure>
@@ -181,6 +182,7 @@ const tagBaseUrl = i18n
                 <Image
                   src={entry.data.image}
                   alt={entry.data.title}
+                  width={384}
                   class="h-full w-full object-cover"
                   loading="lazy"
                 />


### PR DESCRIPTION
## Problem

On the blog index, the featured first post rendered its hero image at full container width with no height constraint. A tall or high-resolution source photo (e.g. 3061×2296) was scaled to ~1280×960 and dominated the page.

On top of that, both the featured banner and the side-card thumbnails were being served at full source resolution: the `<Image>` component received `ImageMetadata` without a `width` prop, so Astro's image pipeline left the dimensions at the original. The user's perception was "the image loaded slowly" because the original 7-megapixel JPEG was actually being delivered.

## Fix

In `packages/blog/astro/BlogIndex.astro`:

- Featured first post: cap the `<figure>` at `max-h-80` and add `h-80 object-cover` on the image so any aspect ratio renders as a 320 px banner.
- Featured first post: pass `width={1600}` so Astro generates a downscaled variant.
- Side card: pass `width={384}` (2× the 192 px figure) so the thumbnail isn't served at full source resolution.

Spotted on `kreistag.levinkeller.de` where a single blog post with a 3061×2296 phone photo was filling the screen and loading slowly.

## Test plan

- [ ] Visit the blog index of a demo with a tall hero image — featured banner is capped at 320 px and not distorted.
- [ ] Inspect network tab — featured banner is a 1600-px-wide variant, side thumbnails are 384-px-wide variants.
- [ ] Existing E2E tests in `apps/demos/single-locale/tests/e2e/multi-blog.spec.ts` still pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145zv9eiK417TyJyJRjbbcd)_